### PR TITLE
feat: typed responses and Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <p align="center">
 
-[![codecov](https://codecov.io/gh/logaretm/villus/branch/master/graph/badge.svg)](https://codecov.io/gh/logaretm/villus)
-[![Build Status](https://travis-ci.org/logaretm/villus.svg?branch=master)](https://travis-ci.org/logaretm/villus)
+[![codecov](https://codecov.io/gh/logaretm/villus/branch/next/graph/badge.svg)](https://codecov.io/gh/logaretm/villus)
+[![Build Status](https://travis-ci.org/logaretm/villus.svg?branch=next)](https://travis-ci.org/logaretm/villus)
 [![Bundle Size](https://badgen.net/bundlephobia/minzip/villus)](https://bundlephobia.com/result?p=villus@0.1.0)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/8d6ba0a78903476dac459c15506ff312)](https://www.codacy.com/app/logaretm/villus?utm_source=github.com&utm_medium=referral&utm_content=logaretm/villus&utm_campaign=Badge_Grade)
 [![npm](https://img.shields.io/npm/dm/villus.svg)](https://npm-stat.com/charts.html?package=villus)

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,17 @@ meta:
     content: A small and fast GraphQL client for Vue.js
 ---
 
+<p align="center">
+
+[![codecov](https://codecov.io/gh/logaretm/villus/branch/next/graph/badge.svg)](https://codecov.io/gh/logaretm/villus)
+[![Build Status](https://travis-ci.org/logaretm/villus.svg?branch=next)](https://travis-ci.org/logaretm/villus)
+[![Bundle Size](https://badgen.net/bundlephobia/minzip/villus)](https://bundlephobia.com/result?p=villus@0.1.0)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/8d6ba0a78903476dac459c15506ff312)](https://www.codacy.com/app/logaretm/villus?utm_source=github.com&utm_medium=referral&utm_content=logaretm/villus&utm_campaign=Badge_Grade)
+[![npm](https://img.shields.io/npm/dm/villus.svg)](https://npm-stat.com/charts.html?package=villus)
+[![npm](https://img.shields.io/npm/v/villus.svg)](https://www.npmjs.com/package/villus)
+
+</p>
+
 ## Quick Start
 
 First install `villus`:

--- a/src/Mutation.ts
+++ b/src/Mutation.ts
@@ -16,7 +16,7 @@ export const Mutation = {
     }
   },
   setup(props: MutationProps, ctx: SetupContext) {
-    const { data, fetching, done, errors, execute } = useMutation({
+    const { data, fetching, done, error, execute } = useMutation({
       ...props
     });
 
@@ -25,7 +25,7 @@ export const Mutation = {
         data: data.value,
         fetching: fetching.value,
         done: done.value,
-        errors: errors.value,
+        error: error.value,
         execute
       });
     };

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -43,13 +43,6 @@ export const Query = {
     }
   },
   setup(props: QueryProps, ctx: SetupContext) {
-    // Checks if its suspended.
-    const query = (props.suspend ? useQuery.suspend : useQuery)({
-      ...toRefs(props),
-      lazy: props.lazy,
-      cachePolicy: props.cachePolicy
-    });
-
     function createRenderFn(api: ReturnType<typeof useQuery>) {
       const { data, errors, fetching, done, execute, pause, resume } = api;
       watch(
@@ -75,10 +68,16 @@ export const Query = {
       };
     }
 
-    if (query instanceof Promise) {
-      return query.then(createRenderFn);
+    const queryProps = {
+      ...toRefs(props),
+      lazy: props.lazy,
+      cachePolicy: props.cachePolicy
+    };
+
+    if (props.suspend) {
+      return useQuery.suspend(queryProps).then(createRenderFn);
     }
 
-    return createRenderFn(query);
+    return createRenderFn(useQuery(queryProps));
   }
 };

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -44,7 +44,7 @@ export const Query = {
   },
   setup(props: QueryProps, ctx: SetupContext) {
     function createRenderFn(api: ReturnType<typeof useQuery>) {
-      const { data, errors, fetching, done, execute, pause, resume } = api;
+      const { data, error, fetching, done, execute, pause, resume } = api;
       watch(
         () => {
           if (props.pause === true) {
@@ -60,7 +60,7 @@ export const Query = {
       return () => {
         return normalizeChildren(ctx, {
           data: data.value,
-          errors: errors.value,
+          error: error.value,
           fetching: fetching.value,
           done: done.value,
           execute

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -30,7 +30,7 @@ export const Subscription = {
     }
   },
   setup(props: SubscriptionProps, ctx: SetupContext) {
-    const { data, errors, pause, paused, resume } = useSubscription(
+    const { data, error, pause, paused, resume } = useSubscription(
       {
         ...props
       },
@@ -40,7 +40,7 @@ export const Subscription = {
     return () => {
       return normalizeChildren(ctx, {
         data: data.value,
-        errors: errors.value,
+        error: error.value,
         pause,
         paused: paused.value,
         resume

--- a/src/client.ts
+++ b/src/client.ts
@@ -111,11 +111,15 @@ export class VqlClient {
     return lazyFetch();
   }
 
-  public async executeMutation(operation: Operation): Promise<OperationResult> {
+  public async executeMutation<TData = any, TVars = QueryVariables>(
+    operation: Operation<TVars>
+  ): Promise<OperationResult> {
     const fetchOptions = this.context ? this.context().fetchOptions : {};
     const opts = makeFetchOptions(operation, fetchOptions || {});
 
-    return this.fetch(this.url, opts).then(response => response.json());
+    return this.fetch(this.url, opts)
+      .then(response => response.json())
+      .then(res => res as OperationResult<TData>);
   }
 
   public executeSubscription(operation: Operation) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,7 +16,9 @@ interface GraphQLRequestContext {
 
 type ContextFactory = () => GraphQLRequestContext;
 
-type SubscriptionForwarder = (operation: Operation) => ObservableLike<OperationResult>;
+type SubscriptionForwarder<TData = any, TVars = QueryVariables> = (
+  operation: Operation<TVars>
+) => ObservableLike<OperationResult<TData>>;
 
 export interface VqlClientOptions {
   url: string;
@@ -122,12 +124,12 @@ export class VqlClient {
       .then(res => res as OperationResult<TData>);
   }
 
-  public executeSubscription(operation: Operation) {
+  public executeSubscription<TData = any, TVars = QueryVariables>(operation: Operation<TVars>) {
     if (!this.subscriptionForwarder) {
       throw new Error('No subscription forwarder was set.');
     }
 
-    return this.subscriptionForwarder(operation);
+    return (this.subscriptionForwarder as SubscriptionForwarder<TData, TVars>)(operation);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,18 @@
 import { Ref } from 'vue';
 import { DocumentNode } from 'graphql';
 
-export interface OperationResult {
-  data: any;
+export interface OperationResult<TData = any> {
+  data: TData;
   errors: any;
 }
 
 export type CachePolicy = 'cache-and-network' | 'network-only' | 'cache-first';
 
-export interface Operation {
+export type QueryVariables = { [k: string]: any };
+
+export interface Operation<TVars = QueryVariables> {
   query: string | DocumentNode;
-  variables?: { [k: string]: any };
+  variables?: TVars;
 }
 
 export interface ObserverLike<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,10 @@
 import { Ref } from 'vue';
 import { DocumentNode } from 'graphql';
+import { CombinedError } from './utils';
 
 export interface OperationResult<TData = any> {
   data: TData | null;
-  errors: any | null;
+  error: CombinedError | null;
 }
 
 export type CachePolicy = 'cache-and-network' | 'network-only' | 'cache-first';
@@ -31,3 +32,8 @@ export interface ObservableLike<T> {
 }
 
 export type MaybeReactive<T> = T | Ref<T>;
+
+export interface GraphQLResponse<TData> {
+  data: TData;
+  errors: any;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export interface OperationResult<TData = any> {
 
 export type CachePolicy = 'cache-and-network' | 'network-only' | 'cache-first';
 
-export type QueryVariables = { [k: string]: any };
+export type QueryVariables = Record<string, any>;
 
 export interface Operation<TVars = QueryVariables> {
   query: string | DocumentNode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,8 @@ import { Ref } from 'vue';
 import { DocumentNode } from 'graphql';
 
 export interface OperationResult<TData = any> {
-  data: TData;
-  errors: any;
+  data: TData | null;
+  errors: any | null;
 }
 
 export type CachePolicy = 'cache-and-network' | 'network-only' | 'cache-first';

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -19,23 +19,17 @@ export function useMutation<TData = any, TVars = QueryVariables>({ query }: Muta
   const error: Ref<CombinedError | null> = ref(null);
 
   async function execute(variables: TVars) {
-    try {
-      fetching.value = true;
-      const vars = variables || {};
-      const res = await client.executeMutation<TData, TVars>({
-        query,
-        variables: vars as TVars // FIXME: fix this casting
-      });
+    fetching.value = true;
+    const vars = variables || {};
+    const res = await client.executeMutation<TData, TVars>({
+      query,
+      variables: vars as TVars // FIXME: fix this casting
+    });
 
-      data.value = res.data;
-      error.value = res.error;
-    } catch (err) {
-      error.value = err;
-      data.value = null;
-    } finally {
-      done.value = true;
-      fetching.value = false;
-    }
+    data.value = res.data;
+    error.value = res.error;
+    done.value = true;
+    fetching.value = false;
   }
 
   return { data, fetching, done, error, execute };

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -1,29 +1,29 @@
 import { ref, Ref, inject } from 'vue';
-import { Operation } from './types';
+import { Operation, QueryVariables } from './types';
 import { VqlClient } from './client';
 
 interface MutationCompositeOptions {
   query: Operation['query'];
 }
 
-export function useMutation({ query }: MutationCompositeOptions) {
+export function useMutation<TData = any, TVars = QueryVariables>({ query }: MutationCompositeOptions) {
   const client = inject('$villus') as VqlClient;
   if (!client) {
     throw new Error('Cannot detect villus Client, did you forget to call `useClient`?');
   }
 
-  const data: Ref<Record<string, any> | null> = ref(null);
+  const data: Ref<TData | null> = ref(null);
   const fetching = ref(false);
   const done = ref(false);
   const errors: Ref<any[] | null> = ref(null);
 
-  async function execute(variables: Operation['variables'] = {}) {
+  async function execute(variables: TVars) {
     try {
       fetching.value = true;
       const vars = variables || {};
-      const res = await client.executeMutation({
+      const res = await client.executeMutation<TData, TVars>({
         query,
-        variables: vars
+        variables: vars as TVars // FIXME: fix this casting
       });
 
       data.value = res.data;

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -1,6 +1,7 @@
 import { ref, Ref, inject } from 'vue';
 import { Operation, QueryVariables } from './types';
 import { VqlClient } from './client';
+import { CombinedError } from './utils';
 
 interface MutationCompositeOptions {
   query: Operation['query'];
@@ -15,7 +16,7 @@ export function useMutation<TData = any, TVars = QueryVariables>({ query }: Muta
   const data: Ref<TData | null> = ref(null);
   const fetching = ref(false);
   const done = ref(false);
-  const errors: Ref<any[] | null> = ref(null);
+  const error: Ref<CombinedError | null> = ref(null);
 
   async function execute(variables: TVars) {
     try {
@@ -27,9 +28,9 @@ export function useMutation<TData = any, TVars = QueryVariables>({ query }: Muta
       });
 
       data.value = res.data;
-      errors.value = res.errors;
+      error.value = res.error;
     } catch (err) {
-      errors.value = [err];
+      error.value = err;
       data.value = null;
     } finally {
       done.value = true;
@@ -37,5 +38,5 @@ export function useMutation<TData = any, TVars = QueryVariables>({ query }: Muta
     }
   }
 
-  return { data, fetching, done, errors, execute };
+  return { data, fetching, done, error, execute };
 }

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -23,24 +23,18 @@ function _useQuery<TData, TVars>({ query, variables, cachePolicy }: QueryComposi
   const error: Ref<CombinedError | null> = ref(null);
 
   async function execute(overrideOpts: { cachePolicy?: CachePolicy } = {}) {
-    try {
-      fetching.value = true;
-      const vars = (isRef(variables) ? variables.value : variables) || {};
-      const res = await client.executeQuery<TData, TVars>({
-        query: isRef(query) ? query.value : query,
-        variables: vars as TVars, // FIXME: Try to avoid casting
-        cachePolicy: overrideOpts?.cachePolicy || cachePolicy
-      });
+    fetching.value = true;
+    const vars = (isRef(variables) ? variables.value : variables) || {};
+    const res = await client.executeQuery<TData, TVars>({
+      query: isRef(query) ? query.value : query,
+      variables: vars as TVars, // FIXME: Try to avoid casting
+      cachePolicy: overrideOpts?.cachePolicy || cachePolicy
+    });
 
-      data.value = res.data;
-      error.value = res.error;
-    } catch (err) {
-      error.value = err;
-      data.value = null;
-    } finally {
-      done.value = true;
-      fetching.value = false;
-    }
+    data.value = res.data;
+    error.value = res.error;
+    done.value = true;
+    fetching.value = false;
   }
 
   if (isRef(query)) {

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -2,7 +2,7 @@ import stringify from 'fast-json-stable-stringify';
 import { ref, Ref, inject, isRef, onMounted, watch, readonly } from 'vue';
 import { CachePolicy, MaybeReactive, Operation, QueryVariables } from './types';
 import { VqlClient } from './client';
-import { hash } from './utils';
+import { hash, CombinedError } from './utils';
 
 interface QueryCompositeOptions<TVars> {
   query: MaybeReactive<Operation['query']>;
@@ -20,7 +20,7 @@ function _useQuery<TData, TVars>({ query, variables, cachePolicy }: QueryComposi
   const data: Ref<TData | null> = ref(null);
   const fetching = ref(false);
   const done = ref(false);
-  const errors: Ref<any[] | null> = ref(null);
+  const error: Ref<CombinedError | null> = ref(null);
 
   async function execute(overrideOpts: { cachePolicy?: CachePolicy } = {}) {
     try {
@@ -33,9 +33,9 @@ function _useQuery<TData, TVars>({ query, variables, cachePolicy }: QueryComposi
       });
 
       data.value = res.data;
-      errors.value = res.errors;
+      error.value = res.error;
     } catch (err) {
-      errors.value = [err];
+      error.value = err;
       data.value = null;
     } finally {
       done.value = true;
@@ -88,7 +88,7 @@ function _useQuery<TData, TVars>({ query, variables, cachePolicy }: QueryComposi
 
   watchVars();
 
-  return { data, fetching, done, errors, execute, pause, paused: readonly(paused), resume };
+  return { data, fetching, done, error, execute, pause, paused: readonly(paused), resume };
 }
 
 function useQuery<TData = any, TVars = QueryVariables>(opts: QueryCompositeOptions<TVars>) {

--- a/src/useSubscription.ts
+++ b/src/useSubscription.ts
@@ -8,11 +8,11 @@ interface SubscriptionCompositeOptions<TVars> {
   variables?: TVars;
 }
 
-export type Reducer<TData = any, TResult = any> = (prev: TResult | null, value: OperationResult<TData>) => TResult;
+export type Reducer<TData = any, TResult = TData> = (prev: TResult | null, value: OperationResult<TData>) => TResult;
 
 export const defaultReducer: Reducer = (_, val) => val.data;
 
-export function useSubscription<TData = any, TResult = any, TVars = QueryVariables>(
+export function useSubscription<TData = any, TResult = TData, TVars = QueryVariables>(
   { query, variables }: SubscriptionCompositeOptions<TVars>,
   reduce: Reducer<TData, TResult> = defaultReducer
 ) {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,73 @@
+import { GraphQLError } from 'graphql';
+
+// https://github.com/FormidableLabs/urql/blob/master/src/utils/error.ts
+const generateErrorMessage = (networkError?: Error, graphqlErrors?: GraphQLError[]) => {
+  let error = '';
+  if (networkError !== undefined) {
+    return (error = `[Network] ${networkError.message}`);
+  }
+
+  if (graphqlErrors !== undefined) {
+    graphqlErrors.forEach(err => {
+      error += `[GraphQL] ${err.message}\n`;
+    });
+  }
+
+  return error.trim();
+};
+
+function normalizeGqlError(error: any): GraphQLError {
+  if (typeof error === 'string') {
+    return new GraphQLError(error);
+  }
+
+  if (typeof error === 'object' && error.message) {
+    return new GraphQLError(
+      error.message,
+      error.nodes,
+      error.source,
+      error.positions,
+      error.path,
+      error,
+      error.extensions || {}
+    );
+  }
+
+  return error as any;
+}
+
+export class CombinedError extends Error {
+  public name: 'CombinedError';
+  public message: string;
+  public response: any;
+  public networkError?: Error;
+  public graphqlErrors?: GraphQLError[];
+
+  constructor({
+    response,
+    networkError,
+    graphqlErrors
+  }: {
+    response: any;
+    networkError?: Error;
+    graphqlErrors?: Array<string | GraphQLError | Error>;
+  }) {
+    const gqlErrors = graphqlErrors?.map(normalizeGqlError);
+    const message = generateErrorMessage(networkError, gqlErrors);
+    super(message);
+
+    this.name = 'CombinedError';
+    this.response = response;
+    this.message = message;
+    this.networkError = networkError;
+    this.graphqlErrors = gqlErrors;
+  }
+
+  get isGraphQLError(): boolean {
+    return !!(this.graphqlErrors && this.graphqlErrors.length);
+  }
+
+  toString() {
+    return this.message;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './query';
+export * from './vnode';
+export * from './error';

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,0 +1,24 @@
+import { GraphQLResponse } from '../types';
+
+interface ParsedResponse<TData> {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  body: GraphQLResponse<TData> | null;
+}
+
+export async function parseResponse<TData>(response: Response): Promise<ParsedResponse<TData>> {
+  let json: GraphQLResponse<TData>;
+  try {
+    json = await response.json();
+  } catch {
+    return response as ParsedResponse<TData>;
+  }
+
+  return {
+    ok: response.ok,
+    statusText: response.statusText,
+    status: response.status,
+    body: json
+  };
+}

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -9,16 +9,24 @@ interface ParsedResponse<TData> {
 
 export async function parseResponse<TData>(response: Response): Promise<ParsedResponse<TData>> {
   let json: GraphQLResponse<TData>;
+  const responseData = {
+    ok: response.ok,
+    statusText: response.statusText,
+    status: response.status
+  };
+
   try {
     json = await response.json();
-  } catch {
-    return response as ParsedResponse<TData>;
+  } catch (err) {
+    return {
+      ...responseData,
+      statusText: err.message,
+      body: null
+    };
   }
 
   return {
-    ok: response.ok,
-    statusText: response.statusText,
-    status: response.status,
+    ...responseData,
     body: json
   };
 }

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -1,7 +1,6 @@
 import { DocumentNode, print } from 'graphql';
 import stringify from 'fast-json-stable-stringify';
-import { SetupContext } from 'vue';
-import { Operation } from './types';
+import { Operation } from '../types';
 
 /**
  * Normalizes a query string or object to a string.
@@ -32,12 +31,4 @@ export function getQueryKey(operation: Operation) {
   const query = normalizeQuery(operation.query);
 
   return hash(`${query}${variables}`);
-}
-
-export function normalizeChildren(context: SetupContext, slotProps: any) {
-  if (!context.slots.default) {
-    return [];
-  }
-
-  return context.slots.default(slotProps) || [];
 }

--- a/src/utils/vnode.ts
+++ b/src/utils/vnode.ts
@@ -1,0 +1,9 @@
+import { SetupContext } from 'vue';
+
+export function normalizeChildren(context: SetupContext, slotProps: any) {
+  if (!context.slots.default) {
+    return [];
+  }
+
+  return context.slots.default(slotProps) || [];
+}

--- a/test/mutation.spec.ts
+++ b/test/mutation.spec.ts
@@ -60,9 +60,9 @@ test('handles errors', async () => {
       <div>
         <Provider :client="client">
           <div>
-            <Mutation query="mutation { likePost (id: 123) { message } }" v-slot="{ errors, execute }">
-              <div v-if="errors">
-                <p>{{ errors[0].message }}</p>
+            <Mutation query="mutation { likePost (id: 123) { message } }" v-slot="{ error, execute }">
+              <div v-if="error">
+                <p>{{ error.message }}</p>
               </div>
               <button @click="execute()"></button>
             </Mutation>
@@ -74,5 +74,5 @@ test('handles errors', async () => {
 
   document.querySelector('button')?.dispatchEvent(new Event('click'));
   await flushPromises();
-  expect(document.querySelector('p')?.textContent).toBe('Network Error');
+  expect(document.querySelector('p')?.textContent).toContain('Network Error');
 });

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -39,7 +39,7 @@ test('executes queries on mounted', async () => {
   await flushPromises();
   // cache was used.
   expect(fetch).toHaveBeenCalledTimes(1);
-  expect(vm.$el.querySelectorAll('li').length).toBe(5);
+  expect(document.querySelectorAll('li').length).toBe(5);
 });
 
 test('caches queries by default', async () => {
@@ -326,7 +326,7 @@ test.skip('can be suspended', async () => {
 
   expect(document.body.textContent).toBe('Loading...');
   await flushPromises();
-  expect(vm.$el.querySelectorAll('li').length).toBe(5);
+  expect(document.querySelectorAll('li').length).toBe(5);
 });
 
 test('Handles query errors', async () => {
@@ -345,11 +345,11 @@ test('Handles query errors', async () => {
     template: `
         <Provider :client="client">
           <div>
-            <Query query="{ posts { id title propNotFound } }" v-slot="{ data, errors }">
+            <Query query="{ posts { id title propNotFound } }" v-slot="{ data, error }">
               <ul v-if="data">
                 <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
               </ul>
-              <p id="error" v-if="errors">{{ errors[0].message }}</p>
+              <p id="error" v-if="error">{{ error.message }}</p>
             </Query>
           </div>
         </Provider>
@@ -378,11 +378,11 @@ test('Handles external errors', async () => {
     template: `
         <Provider :client="client">
           <div>
-            <Query query="{ posts { id title propNotFound } }" v-slot="{ data, errors }">
+            <Query query="{ posts { id title propNotFound } }" v-slot="{ data, error }">
               <ul v-if="data">
                 <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
               </ul>
-              <p id="error" v-if="errors">{{ errors[0].message }}</p>
+              <p id="error" v-if="error">{{ error.message }}</p>
             </Query>
           </div>
         </Provider>

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -392,3 +392,31 @@ test('Handles external errors', async () => {
   await flushPromises();
   expect(document.querySelector('#error')?.textContent).toMatch(/Network Error/);
 });
+
+test('Handles empty slots', async () => {
+  const client = createClient({
+    url: 'https://test.com/graphql'
+  });
+
+  (global as any).fetchController.simulateNetworkError = true;
+
+  mount({
+    data: () => ({
+      client
+    }),
+    components: {
+      Query,
+      Provider
+    },
+    template: `
+        <Provider :client="client">
+          <div id="body">
+            <Query query="{ posts { id title propNotFound } }" v-slot="{ data, error }"></Query>
+          </div>
+        </Provider>
+      `
+  });
+
+  await flushPromises();
+  expect(document.querySelector('#body')?.textContent).toBe('');
+});

--- a/test/server/setup.ts
+++ b/test/server/setup.ts
@@ -31,7 +31,8 @@ const server = mockServer(schema, {
 
 beforeEach(() => {
   const fetchController = {
-    simulateNetworkError: false
+    simulateNetworkError: false,
+    simulateParseError: false
   };
 
   (global as any).fetchController = fetchController;
@@ -50,6 +51,10 @@ beforeEach(() => {
       status: 200,
       statusText: 'OK',
       json() {
+        if (fetchController.simulateParseError) {
+          throw new Error('Error parsing, unexpected token <');
+        }
+
         return res;
       }
     });

--- a/test/server/setup.ts
+++ b/test/server/setup.ts
@@ -46,6 +46,9 @@ beforeEach(() => {
     const res = await server.query(body.query, body.variables);
 
     return Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
       json() {
         return res;
       }

--- a/test/server/typedSchema.ts
+++ b/test/server/typedSchema.ts
@@ -1,0 +1,13 @@
+export interface Post {
+  id: number;
+  title: string;
+  slug: string;
+  isLiked: boolean;
+}
+
+export interface LikePostMutationResponse {
+  success: boolean;
+  code: string;
+  message: string;
+  post: Post;
+}

--- a/test/subscription.spec.ts
+++ b/test/subscription.spec.ts
@@ -95,8 +95,8 @@ test('Handles observer errors', async () => {
     template: `
       <div>
         <Provider :client="client">
-          <Subscription query="subscription { newMessages }" v-slot="{ errors }">
-            <p v-if="errors">{{ errors[0].message }}</p>
+          <Subscription query="subscription { newMessages }" v-slot="{ error }">
+            <p v-if="error">{{ error.message }}</p>
           </Subscription>
         </Provider>
       </div>
@@ -105,7 +105,7 @@ test('Handles observer errors', async () => {
 
   await (global as any).sleep(150);
   await flushPromises();
-  expect(document.querySelector('p')?.textContent).toBe('oops!');
+  expect(document.querySelector('p')?.textContent).toContain('oops!');
 });
 
 test('Fails if provider was not resolved', async () => {

--- a/test/useMutation.spec.ts
+++ b/test/useMutation.spec.ts
@@ -2,6 +2,7 @@
 import { mount } from './helpers/mount';
 import flushPromises from 'flush-promises';
 import { useClient, useMutation } from '../src/index';
+import { LikePostMutationResponse } from './server/typedSchema';
 
 test('runs mutations', async () => {
   const vm = mount({
@@ -10,7 +11,9 @@ test('runs mutations', async () => {
         url: 'https://test.com/graphql'
       });
 
-      const { data, execute } = useMutation({ query: 'mutation { likePost (id: 123) { message } }' });
+      const { data, execute } = useMutation<LikePostMutationResponse>({
+        query: 'mutation { likePost (id: 123) { message } }'
+      });
 
       return { data, execute };
     },

--- a/test/useMutation.spec.ts
+++ b/test/useMutation.spec.ts
@@ -29,11 +29,11 @@ test('runs mutations', async () => {
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(0);
 
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
 
-  expect(vm.$el.querySelector('p')?.textContent).toBe('Operation successful');
+  expect(document.querySelector('p')?.textContent).toBe('Operation successful');
 });
 
 test('passes variables via execute method', async () => {
@@ -61,11 +61,11 @@ test('passes variables via execute method', async () => {
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(0);
 
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
 
-  expect(vm.$el.querySelector('p')?.textContent).toBe('Operation successful');
+  expect(document.querySelector('p')?.textContent).toBe('Operation successful');
 });
 
 test('handles external errors', async () => {
@@ -77,23 +77,23 @@ test('handles external errors', async () => {
         url: 'https://test.com/graphql'
       });
 
-      const { data, execute, errors } = useMutation({ query: 'mutation { likePost (id: 123) { message } }' });
+      const { data, execute, error } = useMutation({ query: 'mutation { likePost (id: 123) { message } }' });
 
-      return { data, execute, errors };
+      return { data, execute, error };
     },
     template: `
     <div>
       <div v-if="data">
         <p>{{ data.likePost.message }}</p>
       </div>
-      <p id="error" v-if="errors">{{ errors[0].message }}</p>
+      <p id="error" v-if="error">{{ error.message }}</p>
       <button @click="execute()"></button>
     </div>`
   });
 
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
   await flushPromises();
-  expect(vm.$el.querySelector('#error')?.textContent).toBe('Network Error');
+  expect(document.querySelector('#error')?.textContent).toContain('Network Error');
 });
 
 test('Fails if provider was not resolved', () => {

--- a/test/useQuery.spec.ts
+++ b/test/useQuery.spec.ts
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import { mount } from './helpers/mount';
 import flushPromises from 'flush-promises';
 import { useClient, useQuery } from '../src/index';
+import { Post } from './server/typedSchema';
 
 test('executes hook queries on mounted', async () => {
   const vm = mount({
@@ -12,7 +13,7 @@ test('executes hook queries on mounted', async () => {
         url: 'https://test.com/graphql'
       });
 
-      const { data } = useQuery({ query: '{ posts { id title } }' });
+      const { data } = useQuery<{ posts: Post[] }>({ query: '{ posts { id title } }' });
 
       return { data };
     },

--- a/test/useQuery.spec.ts
+++ b/test/useQuery.spec.ts
@@ -13,12 +13,13 @@ test('executes hook queries on mounted', async () => {
         url: 'https://test.com/graphql'
       });
 
-      const { data } = useQuery<{ posts: Post[] }>({ query: '{ posts { id title } }' });
+      const { data, error } = useQuery<{ posts: Post[] }>({ query: '{ posts { id title } }' });
 
-      return { data };
+      return { data, error };
     },
     template: `
-    <div>
+    <div>'
+      <div>{{ error }}</div>
       <ul v-if="data">
         <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
       </ul>
@@ -26,7 +27,8 @@ test('executes hook queries on mounted', async () => {
   });
 
   await flushPromises();
-  expect(vm.$el.querySelectorAll('li').length).toBe(5);
+
+  expect(document.querySelectorAll('li').length).toBe(5);
 });
 
 test('works with tagged queries', async () => {
@@ -58,7 +60,7 @@ test('works with tagged queries', async () => {
   });
 
   await flushPromises();
-  expect(vm.$el.querySelectorAll('li').length).toBe(5);
+  expect(document.querySelectorAll('li').length).toBe(5);
 });
 
 test('caches queries by default', async () => {
@@ -83,7 +85,7 @@ test('caches queries by default', async () => {
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
 
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
   await flushPromises();
   // cache was used.
   expect(fetch).toHaveBeenCalledTimes(1);
@@ -118,13 +120,13 @@ test('re-runs reactive queries automatically', async () => {
 
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
-  expect(vm.$el.querySelector('h1')?.textContent).toContain('12');
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  expect(document.querySelector('h1')?.textContent).toContain('12');
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
 
   await flushPromises();
   // fetch was triggered a second time, due to variable change.
   expect(fetch).toHaveBeenCalledTimes(2);
-  expect(vm.$el.querySelector('h1')?.textContent).toContain('13');
+  expect(document.querySelector('h1')?.textContent).toContain('13');
 });
 
 test('cache policy can be overridden with execute function', async () => {
@@ -150,7 +152,7 @@ test('cache policy can be overridden with execute function', async () => {
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
 
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
   await flushPromises();
   // fetch was triggered a second time.
   expect(fetch).toHaveBeenCalledTimes(2);
@@ -179,7 +181,7 @@ test('cache policy can be overridden with cachePolicy option', async () => {
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
 
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
   await flushPromises();
   // fetch was triggered a second time.
   expect(fetch).toHaveBeenCalledTimes(2);
@@ -214,13 +216,13 @@ test('variables are watched by default if reactive', async () => {
 
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
-  expect(vm.$el.querySelector('h1')?.textContent).toContain('12');
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  expect(document.querySelector('h1')?.textContent).toContain('12');
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
 
   await flushPromises();
   // fetch was triggered a second time, due to variable change.
   expect(fetch).toHaveBeenCalledTimes(2);
-  expect(vm.$el.querySelector('h1')?.textContent).toContain('13');
+  expect(document.querySelector('h1')?.textContent).toContain('13');
 });
 
 test('variables watcher can be disabled', async () => {
@@ -254,22 +256,22 @@ test('variables watcher can be disabled', async () => {
 
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
-  expect(vm.$el.querySelector('h1')?.textContent).toContain('12');
-  vm.$el.querySelector('#toggle')?.dispatchEvent(new Event('click'));
-  vm.$el.querySelector('#change')?.dispatchEvent(new Event('click'));
+  expect(document.querySelector('h1')?.textContent).toContain('12');
+  document.querySelector('#toggle')?.dispatchEvent(new Event('click'));
+  document.querySelector('#change')?.dispatchEvent(new Event('click'));
 
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
-  expect(vm.$el.querySelector('h1')?.textContent).toContain('12');
-  expect(vm.$el.querySelector('#status')?.textContent).toContain('true');
+  expect(document.querySelector('h1')?.textContent).toContain('12');
+  expect(document.querySelector('#status')?.textContent).toContain('true');
 
   // toggle it back
-  vm.$el.querySelector('#toggle')?.dispatchEvent(new Event('click'));
-  vm.$el.querySelector('#change')?.dispatchEvent(new Event('click'));
+  document.querySelector('#toggle')?.dispatchEvent(new Event('click'));
+  document.querySelector('#change')?.dispatchEvent(new Event('click'));
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(2);
-  expect(vm.$el.querySelector('h1')?.textContent).toContain('14');
-  expect(vm.$el.querySelector('#status')?.textContent).toContain('false');
+  expect(document.querySelector('h1')?.textContent).toContain('14');
+  expect(document.querySelector('#status')?.textContent).toContain('false');
 });
 
 test('variables prop arrangement does not trigger queries', async () => {
@@ -302,9 +304,9 @@ test('variables prop arrangement does not trigger queries', async () => {
 
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
-  expect(vm.$el.querySelector('h1')?.textContent).toContain('12');
+  expect(document.querySelector('h1')?.textContent).toContain('12');
 
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
 });
@@ -345,7 +347,7 @@ test('can be suspended', async () => {
 
   expect(document.body.textContent).toBe('Loading...');
   await flushPromises();
-  expect(vm.$el.querySelectorAll('li').length).toBe(5);
+  expect(document.querySelectorAll('li').length).toBe(5);
 });
 
 test('Handles query errors', async () => {
@@ -355,23 +357,23 @@ test('Handles query errors', async () => {
         url: 'https://test.com/graphql'
       });
 
-      const { data, errors } = useQuery({
+      const { data, error } = useQuery({
         query: '{ posts { id title propNotFound } }'
       });
 
-      return { data, errors };
+      return { data, error };
     },
     template: `
     <div>
       <div v-if="data">
         <h1>It shouldn't work!</h1>
       </div>
-      <p id="error" v-if="errors">{{ errors[0].message }}</p>
+      <p id="error" v-if="error">{{ error.message }}</p>
     </div>`
   });
 
   await flushPromises();
-  expect(vm.$el.querySelector('#error')?.textContent).toMatch(/Cannot query field/);
+  expect(document.querySelector('#error')?.textContent).toMatch(/Cannot query field/);
 });
 
 test('Handles external errors', async () => {
@@ -383,32 +385,32 @@ test('Handles external errors', async () => {
         url: 'https://test.com/graphql'
       });
 
-      const { data, errors } = useQuery({
+      const { data, error } = useQuery({
         query: '{ posts { id title } }'
       });
 
-      return { data, errors };
+      return { data, error };
     },
     template: `
     <div>
       <div v-if="data">
         <h1>It shouldn't work!</h1>
       </div>
-      <p id="error" v-if="errors">{{ errors[0].message }}</p>
+      <p id="error" v-if="error">{{ error.message }}</p>
     </div>`
   });
 
   await flushPromises();
-  expect(vm.$el.querySelector('#error')?.textContent).toMatch(/Network Error/);
+  expect(document.querySelector('#error')?.textContent).toMatch(/Network Error/);
 });
 
 test('Fails if provider was not resolved', () => {
   try {
     mount({
       setup() {
-        const { data, errors } = useQuery({ query: `{ posts { id title } }` });
+        const { data, error } = useQuery({ query: `{ posts { id title } }` });
 
-        return { messages: data, errors };
+        return { messages: data, error };
       },
       template: `
       <div>

--- a/test/useQuery.spec.ts
+++ b/test/useQuery.spec.ts
@@ -376,7 +376,35 @@ test('Handles query errors', async () => {
   expect(document.querySelector('#error')?.textContent).toMatch(/Cannot query field/);
 });
 
-test('Handles external errors', async () => {
+test('Handles parse errors', async () => {
+  (global as any).fetchController.simulateParseError = true;
+
+  const vm = mount({
+    setup() {
+      useClient({
+        url: 'https://test.com/graphql'
+      });
+
+      const { data, error } = useQuery({
+        query: '{ posts { id title } }'
+      });
+
+      return { data, error };
+    },
+    template: `
+    <div>
+      <div v-if="data">
+        <h1>It shouldn't work!</h1>
+      </div>
+      <p id="error" v-if="error">{{ error.message }}</p>
+    </div>`
+  });
+
+  await flushPromises();
+  expect(document.querySelector('#error')?.textContent).toMatch(/Error parsing/);
+});
+
+test('Handles network errors', async () => {
   (global as any).fetchController.simulateNetworkError = true;
 
   const vm = mount({

--- a/test/useQuery.spec.ts
+++ b/test/useQuery.spec.ts
@@ -453,3 +453,59 @@ test('Fails if provider was not resolved', () => {
     expect(err.message).toContain('Cannot detect villus Client');
   }
 });
+
+test('Errors are stringified nicely to their messages', async () => {
+  (global as any).fetchController.simulateNetworkError = true;
+
+  const vm = mount({
+    setup() {
+      useClient({
+        url: 'https://test.com/graphql'
+      });
+
+      const { data, error } = useQuery({
+        query: '{ posts { id title } }'
+      });
+
+      return { data, error };
+    },
+    template: `
+    <div>
+      <div v-if="data">
+        <h1>It shouldn't work!</h1>
+      </div>
+      <p id="error" v-if="error">{{ error.toString() }}</p>
+    </div>`
+  });
+
+  await flushPromises();
+  expect(document.querySelector('#error')?.textContent).toMatch(/Network Error/);
+});
+
+test('Errors can be separated by type', async () => {
+  (global as any).fetchController.simulateNetworkError = true;
+
+  const vm = mount({
+    setup() {
+      useClient({
+        url: 'https://test.com/graphql'
+      });
+
+      const { data, error } = useQuery({
+        query: '{ posts { id title } }'
+      });
+
+      return { data, error };
+    },
+    template: `
+    <div>
+      <div v-if="data">
+        <h1>It shouldn't work!</h1>
+      </div>
+      <p id="error" v-if="error">{{ error.isGraphQLError ? 'GraphQL' : 'Network' }}</p>
+    </div>`
+  });
+
+  await flushPromises();
+  expect(document.querySelector('#error')?.textContent).toBe('Network');
+});

--- a/test/useSubscription.spec.ts
+++ b/test/useSubscription.spec.ts
@@ -6,6 +6,11 @@ import { useClient, useSubscription } from '../src/index';
 
 jest.useFakeTimers();
 
+interface Message {
+  id: number;
+  message: string;
+}
+
 test('Default reducer', async () => {
   const vm = mount({
     setup() {
@@ -16,7 +21,7 @@ test('Default reducer', async () => {
         }
       });
 
-      const { data } = useSubscription({ query: `subscription { newMessages }` });
+      const { data } = useSubscription<Message>({ query: `subscription { newMessages }` });
 
       return { messages: data };
     },
@@ -44,15 +49,13 @@ test('Handles subscriptions with a custom reducer', async () => {
         }
       });
 
-      function reduce(oldMessages: string[], response: any) {
+      const { data } = useSubscription<Message>({ query: `subscription { newMessages }` }, (oldMessages, response) => {
         if (!response.data) {
           return oldMessages || [];
         }
 
         return [...oldMessages, response.data.message];
-      }
-
-      const { data } = useSubscription({ query: `subscription { newMessages }` }, reduce);
+      });
 
       return { messages: data };
     },

--- a/test/useSubscription.spec.ts
+++ b/test/useSubscription.spec.ts
@@ -36,7 +36,7 @@ test('Default reducer', async () => {
 
   jest.advanceTimersByTime(501);
   await flushPromises();
-  expect(vm.$el.querySelector('span')?.textContent).toBe('4');
+  expect(document.querySelector('span')?.textContent).toBe('4');
 });
 
 test('Handles subscriptions with a custom reducer', async () => {
@@ -73,7 +73,7 @@ test('Handles subscriptions with a custom reducer', async () => {
 
   jest.advanceTimersByTime(501);
   await flushPromises();
-  expect(vm.$el.querySelectorAll('li')).toHaveLength(5);
+  expect(document.querySelectorAll('li')).toHaveLength(5);
 });
 
 test('Handles observer errors', async () => {
@@ -94,23 +94,23 @@ test('Handles observer errors', async () => {
         return [...oldMessages, response.data.message];
       }
 
-      const { data, errors } = useSubscription({ query: `subscription { newMessages }` }, reduce);
+      const { data, error } = useSubscription({ query: `subscription { newMessages }` }, reduce);
 
-      return { messages: data, errors };
+      return { messages: data, error };
     },
     template: `
       <div>
         <ul v-for="message in messages">
           <li>{{ message.id }}</li>
         </ul>
-        <p id="error" v-if="errors">{{ errors[0].message }}</p>
+        <p id="error" v-if="error">{{ error.message }}</p>
       </div>
     `
   });
 
   jest.advanceTimersByTime(150);
   await flushPromises();
-  expect(vm.$el.querySelector('#error')?.textContent).toBe('oops!');
+  expect(document.querySelector('#error')?.textContent).toContain('oops!');
 });
 
 test('Pauses and resumes subscriptions', async () => {
@@ -149,33 +149,33 @@ test('Pauses and resumes subscriptions', async () => {
   await flushPromises();
   jest.advanceTimersByTime(201);
   // pauses subscription
-  expect(vm.$el.querySelector('#status')?.textContent).toBe('false');
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  expect(document.querySelector('#status')?.textContent).toBe('false');
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
   await flushPromises();
-  expect(vm.$el.querySelectorAll('li')).toHaveLength(2);
-  expect(vm.$el.querySelector('#status')?.textContent).toBe('true');
-  vm.$el.querySelector('button')?.dispatchEvent(new Event('click'));
+  expect(document.querySelectorAll('li')).toHaveLength(2);
+  expect(document.querySelector('#status')?.textContent).toBe('true');
+  document.querySelector('button')?.dispatchEvent(new Event('click'));
   jest.advanceTimersByTime(201);
   await flushPromises();
 
-  expect(vm.$el.querySelectorAll('li')).toHaveLength(4);
-  expect(vm.$el.querySelector('#status')?.textContent).toBe('false');
+  expect(document.querySelectorAll('li')).toHaveLength(4);
+  expect(document.querySelector('#status')?.textContent).toBe('false');
 });
 
 test('Fails if provider was not resolved', () => {
   try {
     mount({
       setup() {
-        const { data, errors } = useSubscription({ query: `subscription { newMessages }` });
+        const { data, error } = useSubscription({ query: `subscription { newMessages }` });
 
-        return { messages: data, errors };
+        return { messages: data, error };
       },
       template: `
       <div>
         <ul v-for="message in messages">
           <li>{{ message.id }}</li>
         </ul>
-        <p id="error" v-if="errors">{{ errors[0].message }}</p>
+        <p id="error" v-if="errors">{{ error.message }}</p>
       </div>
     `
     });
@@ -192,16 +192,16 @@ test('Fails if subscription forwarder was not set', () => {
         useClient({
           url: 'https://test.com/graphql'
         });
-        const { data, errors } = useSubscription({ query: `subscription { newMessages }` });
+        const { data, error } = useSubscription({ query: `subscription { newMessages }` });
 
-        return { messages: data, errors };
+        return { messages: data, error };
       },
       template: `
       <div>
         <ul v-for="message in messages">
           <li>{{ message.id }}</li>
         </ul>
-        <p id="error" v-if="errors">{{ errors[0].message }}</p>
+        <p id="error" v-if="error">{{ error.message }}</p>
       </div>
     `
     });

--- a/test/useSubscription.spec.ts
+++ b/test/useSubscription.spec.ts
@@ -49,13 +49,16 @@ test('Handles subscriptions with a custom reducer', async () => {
         }
       });
 
-      const { data } = useSubscription<Message>({ query: `subscription { newMessages }` }, (oldMessages, response) => {
-        if (!response.data) {
-          return oldMessages || [];
-        }
+      const { data } = useSubscription<Message, string[]>(
+        { query: `subscription { newMessages }` },
+        (oldMessages, response) => {
+          if (!response.data || !oldMessages) {
+            return oldMessages || [];
+          }
 
-        return [...oldMessages, response.data.message];
-      });
+          return [...oldMessages, response.data.message];
+        }
+      );
 
       return { messages: data };
     },
@@ -83,8 +86,8 @@ test('Handles observer errors', async () => {
         }
       });
 
-      function reduce(oldMessages: string[], response: any) {
-        if (!response.data) {
+      function reduce(oldMessages: string[] | null, response: any): string[] {
+        if (!response.data || !oldMessages) {
           return oldMessages || [];
         }
 
@@ -120,8 +123,8 @@ test('Pauses and resumes subscriptions', async () => {
         }
       });
 
-      function reduce(oldMessages: string[], response: any) {
-        if (!response.data) {
+      function reduce(oldMessages: string[] | null, response: any) {
+        if (!response.data || !oldMessages) {
           return oldMessages || [];
         }
 


### PR DESCRIPTION
So far `villus` only offered basic error handling no typings for returned responses.

**tldr:**

> Breaking change, now `useQuery`, `useMutation`, `useSubscription` and `Query`, `Mutation` and `Subscription` components will no longer expose an `errors` prop/slot-prop and will instead expose a single `error` prop/slot-prop

This PR adds the ability to fully type responses returned from executing queries, mutations, and subscriptions.

## Typed Queries

You can type your queries like this:

```ts
interface Post {
  id: number;
  title: string;
  slug: string;
  isLiked: boolean;
}

interface PostQueryResponse {
  posts: Post[];
}

const { data } = useQuery<PostQueryResponse>({ query: '{ posts { id title } }' });

return { data };
```

You can also type your variables:


```ts
interface Post {
  id: number;
  title: string;
  slug: string;
  isLiked: boolean;
}

interface FindPostQueryResponse {
  post: Post;
}

interface PostQueryVariables {
  id: number;
}

const { data } = useQuery<FindPostQueryResponse, PostQueryVariables>({
  query: `
    query FindPost($id: Int!) {
      post(id: $id) { id title }
    }`,
  variables: { id: 12 }
});

return { data };
```

And you will get typing support when providing variables to your query, the `useMutation` function is identical to `useQuery`.

### Typed Subscriptions

First, you can type the response just like previously seen with `useQuery`:

```ts
interface Message {
  id: number;
  message: string;
}

const { data } = useSubscription<Message>({ query: `subscription { newMessages }` });

return { messages: data };
```

This isn't very useful because subscriptions are event-based, meaning rarely you will be using a single return value from the active subscription, that is why `useSubscription` accepts a reducer that acts as subscription handler, this PR allows you to fully type-proof it:


```ts
interface Message {
  id: number;
  message: string;
}


const { data } = useSubscription<Message, string[]>(
  { query: `subscription { newMessages }` },
  (oldMessages, response) => {
    if (!response.data || !oldMessages) {
      return oldMessages || [];
    }

    return [...oldMessages, response.data.message];
  }
);
```

Both `oldMessages` and `response` will be typed and `data` will now have a type of `string[]` instead of `Message`.

---

## Typed Errors

This is a breaking change, now `useQuery`, `useMutation`, `useSubscription` and `Query`, `Mutation` and `Subscription` components will no longer expose an `errors` prop/slot-prop and will instead expose a single `error` prop/slot-prop, that error object is typed as such:

```ts
interface CombinedError extends Error {
  name: 'CombinedError';
  message: string;
  response: any;
  networkError?: Error;
  graphqlErrors?: GraphQLError[];
  isGraphQLError: boolean;
}
```

This allows you to have better handling and fine-grained control over which error type to handle.