### PR TITLE
feat: support async context

### DIFF
--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -23,3 +23,24 @@ test('fails if executes an non-provided query', async () => {
     expect(err.message).toMatch(/A query must be provide/);
   }
 });
+
+test('supports async context', async () => {
+  const client = createClient({
+    url: 'https://test.com/graphql',
+    context: async () => {
+      return {
+        fetchOptions: {
+          headers: {
+            Authorization: 'bearer TOKEN'
+          }
+        }
+      };
+    }
+  });
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  const { data } = await client.executeQuery({ query: '{ posts { id title } }' });
+
+  expect(data).toBeDefined();
+});


### PR DESCRIPTION
This simple PR adds support for an async context function in client.

This enables other promises to be awaited before requests are made.

For example, one might need to get an access token before executing a request:

```js
const client = createClient({
  url: 'https://test.com/graphql',
  context: async () => {
    // Get the current access token
    const token = await myAuthService.getAccessToken()

    return {
      fetchOptions: {
        headers: {
          Authorization: `bearer ${token}`
        }
      }
    };
  }
});

async function run() {
  // This request will first await the access token, then returned the awaited context
  // before executing the graphql query, with fetchOptions that include the 
  // appropriate authorization header token
  const { data } = await client.executeQuery({ query: '{ posts { id title } }' });
}
```