### PR TITLE
Fix 'errors' typo in docs

### DIFF
--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -416,12 +416,12 @@ The `done` slot prop is a boolean that indicates that the query has been complet
 
 ### errors
 
-The `errors` slot prop contains all errors encountered when running the query.
+The `error` slot prop contains all errors encountered when running the query.
 
 ```vue{1,3}
-<Query query="{ todos { text } }" v-slot="{ data, errors }">
+<Query query="{ todos { text } }" v-slot="{ data, error }">
   <!-- Your Custom component to handle error display -->
-  <ErrorPage v-if="errors" :errors="errors" />
+  <ErrorPage v-if="error" :error="error" />
 
   <div v-else>
     <p v-for="todo in data.todos">{{ todo.text }}</p>
@@ -434,7 +434,7 @@ The `errors` slot prop contains all errors encountered when running the query.
 You can also extract the same properties mentioned above from the `useQuery` function:
 
 ```js
-const { data, fetching, done, errors } = useQuery({
+const { data, fetching, done, error } = useQuery({
   // ...
 });
 ```


### PR DESCRIPTION
The `errors` prop in `useQuery` was returning `undefined` even though I could see the error in the network tab. I couldn't work out why so I tested to see if it should be `error` instead and it worked. I'm not sure if the docs are wrong or if the prop is wrong. Thought I'd send a fix just encase it's the docs.