### PR TITLE
Reset the value of "done" when executing a mutation

### DIFF
--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -19,6 +19,7 @@ export function useMutation<TData = any, TVars = QueryVariables>({ query }: Muta
   const error: Ref<CombinedError | null> = ref(null);
 
   async function execute(variables: TVars) {
+    done.value = false;
     fetching.value = true;
     const vars = variables || {};
     const res = await client.executeMutation<TData, TVars>({

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -23,6 +23,7 @@ function _useQuery<TData, TVars>({ query, variables, cachePolicy }: QueryComposi
   const error = ref<CombinedError | null>(null);
 
   async function execute(overrideOpts: { cachePolicy?: CachePolicy } = {}) {
+    done.value = false;
     fetching.value = true;
     const vars = (isRef(variables) ? variables.value : variables) || {};
     const res = await client.executeQuery<TData, TVars>({


### PR DESCRIPTION
Currently, if you execute a mutation the value of "done" goes from `false` to `true` and never resets back.
Resetting would allow users to watch this value and easily run side effects after each time a mutation completes.