### PR TITLE
fix: prefer function slots for better performance

### DIFF
--- a/src/Provider.ts
+++ b/src/Provider.ts
@@ -30,7 +30,7 @@ export function withProvider(component: any, client: VqlClient) {
       useClient(client);
 
       return () => {
-        return h(component, { ...props, ...ctx.attrs }, normalizeChildren(ctx, {}));
+        return h(component, { ...props, ...ctx.attrs }, ctx.slots);
       };
     }
   });


### PR DESCRIPTION
This resolves the console warning from Vue: `[Vue warn]: Non-function value encountered for default slot. Prefer function slots for better performance. `