### PR TITLE
fix: handle non 200 error responses

### DIFF
--- a/packages/villus/test/server/setup.ts
+++ b/packages/villus/test/server/setup.ts
@@ -30,6 +30,8 @@ beforeEach(() => {
   const fetchController = {
     simulateNetworkError: false,
     simulateParseError: false,
+    // #49
+    simulateNetworkErrorWithGraphQLResponse: false,
   };
 
   (global as any).fetchController = fetchController;
@@ -38,6 +40,20 @@ beforeEach(() => {
   (global as any).fetch = jest.fn(async function mockedAPI(url: string, opts: RequestInit) {
     if (fetchController.simulateNetworkError) {
       throw new Error('Network Error');
+    }
+
+    if (fetchController.simulateNetworkErrorWithGraphQLResponse) {
+      return Promise.resolve({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json() {
+          return {
+            data: null,
+            errors: [{ message: 'Unauthorized' }],
+          };
+        },
+      });
     }
 
     let body: any[] = JSON.parse(opts.body as string);

--- a/packages/villus/test/useQuery.spec.ts
+++ b/packages/villus/test/useQuery.spec.ts
@@ -618,6 +618,35 @@ test('Errors can be separated by type', async () => {
   expect(document.querySelector('#error')?.textContent).toBe('Network');
 });
 
+// # 49
+test('Errors can have non 200 response code', async () => {
+  (global as any).fetchController.simulateNetworkErrorWithGraphQLResponse = true;
+
+  mount({
+    setup() {
+      useClient({
+        url: 'https://test.com/graphql',
+      });
+
+      const { data, error } = useQuery({
+        query: '{ posts { id title } }',
+      });
+
+      return { data, error };
+    },
+    template: `
+    <div>
+      <div v-if="data">
+        <h1>It shouldn't work!</h1>
+      </div>
+      <p id="error" v-if="error">{{ error.isGraphQLError ? 'GraphQL' : 'Network' }}</p>
+    </div>`,
+  });
+
+  await flushPromises();
+  expect(document.querySelector('#error')?.textContent).toBe('GraphQL');
+});
+
 test('cache-only policy returns null results if not found', async () => {
   mount({
     setup() {


### PR DESCRIPTION
This addresses the case where a GraphQL API returns non 200 response when an error is encountered

closes #49 