### PR TITLE
Export `Client` type

### DIFF
--- a/packages/villus/src/index.ts
+++ b/packages/villus/src/index.ts
@@ -1,4 +1,4 @@
-export { createClient, defaultPlugins } from './client';
+export { createClient, defaultPlugins, Client } from './client';
 export { Provider, withProvider } from './Provider';
 export { Query } from './Query';
 export { Mutation } from './Mutation';


### PR DESCRIPTION
Both `useClient` and `createClient` return a `Client`, but the type can't be referenced.

I was trying to keep a reference to `client` to use both in my components and in composables, but the type wasn't exported.