### PR TITLE
feat: breaking API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ coverage
 # logs
 
 *.log
+
+.DS_Store

--- a/docs/content/api/client.md
+++ b/docs/content/api/client.md
@@ -12,13 +12,12 @@ This is a detailed documented of the villus client
 
 The `createClient` function exported by `villus` package allows you to create raw villus client instances to be used freely without being attached to components/composable functions. Here are the options that `createClient` accepts:
 
-| Option                | Description                                                                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| url                   | The URL of the GraphQL API service                                                                                                    |
-| fetch                 | The `fetch` function to be used, must be compatible with `window.fetch`                                                               |
-| cachePolicy           | The global cache policy to be used for queries, possible values are: `cache-and-network`, `network-only`, or `cache-first`            |
-| context               | A function used to add headers, fetch options to all HTTP requests                                                                    |
-| subscriptionForwarder | A function that initiates subscriptions using observable API. Read more about it in the [subscriptions guide](../guide/subscriptions) |
+| Option      | Description                                                                                                                |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| url         | The URL of the GraphQL API service                                                                                         |
+| fetch       | The `fetch` function to be used, must be compatible with `window.fetch`                                                    |
+| cachePolicy | The global cache policy to be used for queries, possible values are: `cache-and-network`, `network-only`, or `cache-first` |
+| context     | A function used to add headers, fetch options to all HTTP requests                                                         |
 
 ```js
 const client = createClient({
@@ -133,14 +132,15 @@ Subscriptions are trickier, because they are more **event-driven**, so you canno
 The `useSubscription` function and `Subscription` component offer a great abstraction for dealing with subscriptions but you can still execute your own arbitrary subscriptions without resorting to either:
 
 ```js
-import { createClient } from 'villus';
+import { createClient, handleSubscriptions, defaultPlugins } from 'villus';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 
 const subscriptionClient = new SubscriptionClient('ws://localhost:4001/graphql', {});
+const subscriptionForwarder = operation => subscriptionClient.request(op),
 
 const client = createClient({
   url: 'http://localhost:4000/graphql',
-  subscriptionForwarder: op => subscriptionClient.request(op),
+  use: [handleSubscriptions(subscriptionForwarder), ...defaultPlugins()],
 });
 
 const observable = client.executeSubscription({
@@ -161,8 +161,8 @@ observable.subscribe({
 });
 ```
 
-<doc-tip>
+<doc-tip type="danger">
 
-Don't forget to set the `subscriptionForwarder` option on the client, which is a function that returns an observable.
+Don't forget to configure the `handleSubscriptions` plugin with a subscription forwarder, which is a function that returns an observable.
 
 </doc-tip>

--- a/docs/content/api/query.md
+++ b/docs/content/api/query.md
@@ -18,14 +18,14 @@ The **Query** component is **renderless** by default, meaning it will not render
 
 The `Query` component accepts the following props:
 
-| Prop        | Type                                                                                         | Required | Description                                                                                           |
-| ----------- | -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| query       | `string` or `DocumentNode`                                                                   | **Yes**  | The query to be executed                                                                              |
-| variables   | `object`                                                                                     | **No**   | The query variables                                                                                   |
-| cachePolicy | A `string` with those possible values `cache-and-network` or `network-only` or `cache-first` | **No**   | The cache policy to execute the query with, defaults to the value configured with the provided client |
-| lazy        | `boolean`                                                                                    | **No**   | If the query **should not** be executed on `mounted`                                                  |
-| suspend     | `boolean`                                                                                    | **No**   | If the component is suspended with `Suspend` or not, defaults to `false`                              |
-| pause       | `boolean`                                                                                    | **No**   | If the query variable watching is disabled or not, defaults to `false`                                |
+| Prop           | Type                                                                                         | Required | Description                                                                                           |
+| -------------- | -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| query          | `string` or `DocumentNode`                                                                   | **Yes**  | The query to be executed                                                                              |
+| variables      | `object`                                                                                     | **No**   | The query variables                                                                                   |
+| cachePolicy    | A `string` with those possible values `cache-and-network` or `network-only` or `cache-first` | **No**   | The cache policy to execute the query with, defaults to the value configured with the provided client |
+| fetchOnMount   | `boolean`                                                                                    | **No**   | If the query **should be** be executed on `onMounted` lifecycle hook, default is `true`               |
+| suspended      | `boolean`                                                                                    | **No**   | If the component is suspended with `Suspend` or not, defaults to `false`                              |
+| watchVariables | `boolean`                                                                                    | **No**   | If the query variable watching is disabled or not, defaults to `true`                                 |
 
 ## Slot Props
 

--- a/docs/content/api/subscription.md
+++ b/docs/content/api/subscription.md
@@ -22,7 +22,7 @@ The `Subscription` component accepts the following props:
 | --------- | ------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | query     | `string` or `DocumentNode`                        | **Yes**  | The subscription to be executed/started                                                                                                          |
 | variables | `object`                                          | **No**   | The subscription variables                                                                                                                       |
-| pause     | `boolean`                                         | **No**   | Activates/Deactivates the subscription, defaults to `false`                                                                                      |
+| paused    | `boolean`                                         | **No**   | Activates/Deactivates the subscription, defaults to `false`                                                                                      |
 | reduce    | `(prev: any, current: ) => any` or `DocumentNode` | **No**   | A reducer used to aggregate the values returned by the subscription, check the [subscription guide for more information](../guide/subscriptions) |
 
 ## Slot Props

--- a/docs/content/api/use-query.md
+++ b/docs/content/api/use-query.md
@@ -10,16 +10,16 @@ The `useQuery` function allows you to execute GraphQL queries, it requires a `Pr
 
 The `useQuery` function returns the following properties and functions:
 
-| Property   | Type                                                              | Description                                                                                                                            |
-| ---------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| data       | `Ref<any/null>`                                                   | The GraphQL query result's `data`                                                                                                      |
-| error      | `Ref<CombinedError>`                                              | Any errors encountered during query execution                                                                                          |
-| execute    | `({cachePolicy: CachePolicy}) => Promise<OperationResult<TData>>` | Executes the query and returns the operation result containing `data` and `error` values                                               |
-| isDone     | `Ref<boolean>`                                                    | Set to true when the query is executed at least once, never resets to `false`                                                          |
-| isFetching | `Ref<boolean>`                                                    | Set to true when the query is executing either by calling `execute` explicitly or by watch effect due to reactive variables or queries |
-| isPaused   | `Ref<boolean>`                                                    | If the variables watchers are enabled or not                                                                                           |
-| pause      | `() => void`                                                      | Pauses variable watching                                                                                                               |
-| resume     | `() => void`                                                      | Resumes variable watching                                                                                                              |
+| Property            | Type                                                              | Description                                                                                                                            |
+| ------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| data                | `Ref<any/null>`                                                   | The GraphQL query result's `data`                                                                                                      |
+| error               | `Ref<CombinedError>`                                              | Any errors encountered during query execution                                                                                          |
+| execute             | `({cachePolicy: CachePolicy}) => Promise<OperationResult<TData>>` | Executes the query and returns the operation result containing `data` and `error` values                                               |
+| isDone              | `Ref<boolean>`                                                    | Set to true when the query is executed at least once, never resets to `false`                                                          |
+| isFetching          | `Ref<boolean>`                                                    | Set to true when the query is executing either by calling `execute` explicitly or by watch effect due to reactive variables or queries |
+| isWatchingVariables | `Ref<boolean>`                                                    | If the variables watchers are enabled or not                                                                                           |
+| unwatchVariables    | `() => void`                                                      | Pauses variable watching                                                                                                               |
+| watchVariables      | `() => void`                                                      | Resumes variable watching                                                                                                              |
 
 There might be undocumented properties, such properties are no intended for public use and should be ignored.
 
@@ -68,14 +68,14 @@ function useQuery<TData = any, TVars = QueryVariables>(
 
 The Second signature is the more complex one, it accepts an object containing the following properties:
 
-| Property    | Type                                                                                         | Required | Description                                                                                           |
-| ----------- | -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| query       | `string` or `DocumentNode` or `Ref<string>`                                                  | **Yes**  | The query to be executed                                                                              |
-| variables   | `object` or `Ref<object>`                                                                    | **No**   | The query variables                                                                                   |
-| cachePolicy | A `string` with those possible values `cache-and-network` or `network-only` or `cache-first` | **No**   | The cache policy to execute the query with, defaults to the value configured with the provided client |
-| lazy        | `boolean`                                                                                    | **No**   | If the query **should not** be executed on `mounted`, default is `false`                              |
+| Property     | Type                                                                                         | Required | Description                                                                                           |
+| ------------ | -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| query        | `string` or `DocumentNode` or `Ref<string>`                                                  | **Yes**  | The query to be executed                                                                              |
+| variables    | `object` or `Ref<object>`                                                                    | **No**   | The query variables                                                                                   |
+| cachePolicy  | A `string` with those possible values `cache-and-network` or `network-only` or `cache-first` | **No**   | The cache policy to execute the query with, defaults to the value configured with the provided client |
+| fetchOnMount | `boolean`                                                                                    | **No**   | If the query **should be** executed on `mounted`, default is `true`                                   |
 
-This signature allows you to tweak the `lazy` and `cachePolicy` behaviors for the query, which is why we needed an extended object. Here is an example:
+This signature allows you to tweak the `fetchOnMount` and `cachePolicy` behaviors for the query, which is why we needed an extended object. Here is an example:
 
 ```js
 const FindTodo = `
@@ -89,7 +89,7 @@ const FindTodo = `
 const { data, error } = useQuery({
   query: FindTodo,
   variables: { id: 1 },
-  lazy: false,
+  fetchOnMount: false,
   cachePolicy: 'network-only',
 });
 ```

--- a/docs/content/api/use-subscription.md
+++ b/docs/content/api/use-subscription.md
@@ -16,7 +16,7 @@ The `useSubscription` function returns the following properties and functions:
 | error    | `Ref<CombinedError>`                                       | Any errors encountered during mutation execution                                            |
 | execute  | `({variables: object}) => Promise<OperationResult<TData>>` | Executes the mutation and returns the operation result containing `data` and `error` values |
 | isPaused | `Ref<boolean>`                                             | True if the subscription is paused or inactive                                              |
-| pause    | `() => void`                                               | Deactivates the subscription temporarily until `resume` is called                           |
+| paused   | `() => void`                                               | Deactivates the subscription temporarily until `resume` is called                           |
 | resume   | `() => void`                                               | Activates the subscription                                                                  |
 
 ## Signature and Usage

--- a/docs/content/guide/plugins.md
+++ b/docs/content/guide/plugins.md
@@ -13,10 +13,6 @@ Something you might not be aware of is that villus is pre-configured with a coup
 - [`fetch`](../plugins/fetch): used to execute queries on the network (actual fetching)
 - [`cache`](../plugins/cache): an in-memory simple cache that comes with villus by default, supports all cache policies
 
-Because of this villus is very minimal and lightweight. That's not all, in addition to those plugins, villus also offers the following plugins but they are not enabled by default:
-
-- [`batch`](../plugins/batch): used instead of `fetch` to execute queries in batches on the network
-
 Furthermore, villus exposes the default plugins as `defaultPlugins` function. To add plugins to villus client you need to pass a `use` array containing the plugins you would like to have
 
 ```js
@@ -28,6 +24,12 @@ useClient({
   use: [...defaultPlugins()], // if not provided `defaultPlugins` will be used
 });
 ```
+
+In addition to the default plugins, villus also offers the following plugins but they are not enabled by default:
+
+- [`batch`](../plugins/batch): used instead of `fetch` to execute queries in batches on the network
+- [`multipart`](../plugins/multipart): Adds File upload support
+- [`handleSubscriptions`](../plugins/handle-subscriptions): Adds GraphQL subscriptions support
 
 ## Plugins under the hood
 

--- a/docs/content/guide/queries.md
+++ b/docs/content/guide/queries.md
@@ -232,13 +232,16 @@ const GetPostById = `
 
 // Create a reactive variables object
 const variables = ref({ id: 123 });
-const { data, pause, resume } = useQuery(GetPostById, variables);
+const { data, watchVariables, unwatchVariables, isWatchingVariables } = useQuery(GetPostById, variables);
 
 // variables/query watching is stopped.
-pause();
+unwatchVariables();
 
 // variables/query watching is resumed.
-resume();
+watchVariables();
+
+// Reports the current watching status true/false
+isWatchingVariables.value;
 ```
 
 ## Caching
@@ -334,6 +337,26 @@ function runWithPolicy() {
 ```
 
 You can build your own cache layer and plugins for villus, check the [Plugins Guide](./plugins)
+
+## Fetching on Mounted
+
+By default the `useQuery` and `Query` component automatically execute their queries when the component is mounted. You can configure this behavior by setting the `fetchOnMounted` option:
+
+```js
+const GetPosts = `
+  query GetPosts {
+    posts {
+      id
+      title
+    }
+  }
+`;
+
+const { data } = useQuery({
+  query: GetPosts,
+  fetchOnMounted: false, // disables query fetching on mounted
+});
+```
 
 ## Suspense
 

--- a/docs/content/guide/subscriptions.md
+++ b/docs/content/guide/subscriptions.md
@@ -8,23 +8,25 @@ order: 5
 
 `villus` handles subscriptions with the `useSubscription` or the `Subscription` component in the same way as the `useQuery` or the `Query` component.
 
-To add support for subscriptions you need to pass a `subscriptionForwarder` function to the `createClient` function, which in turn will call your subscription client. The `subscriptionForwarder` expects an object that follows the [observable spec](https://github.com/tc39/proposal-observable) to be returned.
+To add support for subscriptions you need to add the `handleSubscriptions` plugin to the `useClient` plugin list, which in turn will call your subscription client. The plugin expects an a function that returns an object that follows the [observable spec](https://github.com/tc39/proposal-observable) to be returned, this function is called a **subscription forwarder**
 
 The following example uses `apollo-server` with the `subscriptions-transport-ws` package:
 
 ```js
-import { createClient } from 'villus';
+import { useClient, handleSubscriptions, defaultPlugins } from 'villus';
 import { SubscriptionClient } from 'subscriptions-transport-ws';
 
 const subscriptionClient = new SubscriptionClient('ws://localhost:4001/graphql', {});
+const subscriptionForwarder = operation => subscriptionClient.request(op),
 
-const client = createClient({
+// in your setup
+const client = useClient({
   url: 'http://localhost:4000/graphql',
-  subscriptionForwarder: op => subscriptionClient.request(op),
+  use: [handleSubscriptions(subscriptionForwarder), ...defaultPlugins()]
 });
 ```
 
-Once you've setup the `subscriptionForwarder` function, you can now use the `useSubscription` function or the `Subscription`.
+Once you've setup the `handleSubscriptions` plugin, you can now use the `useSubscription` function or the `Subscription`.
 
 ## Executing Subscriptions
 

--- a/docs/content/plugins/handle-subscriptions.md
+++ b/docs/content/plugins/handle-subscriptions.md
@@ -1,0 +1,31 @@
+---
+title: Handle Subscriptions Plugin
+description: The plugin that executes your subscriptions
+order: 5
+---
+
+# Handle Subscriptions Plugin
+
+Subscriptions are very different from queries or mutations, as it is considered a constant stream of events or data. Because of this it requires special handling, `villus` implements the subscriptions support as a plugin for added flexibility and streamlining the query execution process regardless of its type.
+
+## Options
+
+The `handleSubscriptions` plugin requires only one option, a **subscription forwarder**, which is just a function that returns an observable.
+
+```js
+import { useClient, handleSubscriptions, defaultPlugins } from 'villus';
+import { SubscriptionClient } from 'subscriptions-transport-ws';
+
+const subscriptionClient = new SubscriptionClient('ws://localhost:4001/graphql', {});
+const subscriptionForwarder = operation => subscriptionClient.request(op),
+
+// in your setup
+useClient({
+  url: 'http://localhost:4000/graphql',
+  use: [handleSubscriptions(subscriptionForwarder), ...defaultPlugins()]
+});
+```
+
+## Code
+
+You can check the [source code for the `handleSubscriptions` plugin](https://github.com/logaretm/villus/blob/master/packages/villus/src/handleSubscriptions.ts) and use it as a reference to build your own

--- a/packages/villus/src/Mutation.ts
+++ b/packages/villus/src/Mutation.ts
@@ -1,13 +1,8 @@
-import { SetupContext } from 'vue-demi';
+import { defineComponent, SetupContext } from 'vue-demi';
 import { useMutation } from './useMutation';
 import { normalizeChildren } from './utils';
-import { DocumentNode } from 'graphql';
 
-interface MutationProps {
-  query: string | DocumentNode;
-}
-
-export const Mutation = {
+export const Mutation = defineComponent({
   name: 'Mutation',
   props: {
     query: {
@@ -15,9 +10,9 @@ export const Mutation = {
       required: true,
     },
   },
-  setup(props: MutationProps, ctx: SetupContext) {
+  setup(props, ctx: SetupContext) {
     const { data, isFetching, isDone, error, execute } = useMutation({
-      ...props,
+      query: props.query as string,
     });
 
     return () => {
@@ -30,4 +25,4 @@ export const Mutation = {
       });
     };
   },
-};
+});

--- a/packages/villus/src/Mutation.ts
+++ b/packages/villus/src/Mutation.ts
@@ -1,4 +1,4 @@
-import { defineComponent, SetupContext } from 'vue-demi';
+import { defineComponent } from 'vue-demi';
 import { useMutation } from './useMutation';
 import { normalizeChildren } from './utils';
 
@@ -10,7 +10,7 @@ export const Mutation = defineComponent({
       required: true,
     },
   },
-  setup(props, ctx: SetupContext) {
+  setup(props, ctx) {
     const { data, isFetching, isDone, error, execute } = useMutation({
       query: props.query as string,
     });

--- a/packages/villus/src/Provider.ts
+++ b/packages/villus/src/Provider.ts
@@ -2,7 +2,7 @@ import { defineComponent, h, SetupContext } from 'vue-demi';
 import { normalizeChildren } from './utils';
 import { useClient } from './useClient';
 import { CachePolicy, ClientPlugin } from './types';
-import { ClientOptions, SubscriptionForwarder } from './client';
+import { ClientOptions } from './client';
 
 export const Provider = defineComponent({
   name: 'VillusClientProvider',
@@ -19,17 +19,12 @@ export const Provider = defineComponent({
       type: Array,
       default: undefined,
     },
-    subscriptionForwarder: {
-      type: Function,
-      default: undefined,
-    },
   },
   setup(props, ctx: SetupContext) {
     useClient({
       url: props.url,
       cachePolicy: props.cachePolicy as CachePolicy,
       use: props.use as ClientPlugin[],
-      subscriptionForwarder: props.subscriptionForwarder as SubscriptionForwarder,
     });
 
     return () => {

--- a/packages/villus/src/Query.ts
+++ b/packages/villus/src/Query.ts
@@ -33,7 +33,7 @@ export const Query = {
         return isValid;
       },
     },
-    pause: {
+    watchVariables: {
       type: Boolean,
       default: false,
     },
@@ -41,18 +41,22 @@ export const Query = {
       type: Boolean,
       default: false,
     },
+    fetchOnMount: {
+      type: Boolean,
+      default: true,
+    },
   },
   setup(props: QueryProps, ctx: SetupContext) {
     function createRenderFn(api: QueryComposable<unknown>) {
-      const { data, error, isFetching, isDone, execute, pause, resume } = api;
+      const { data, error, isFetching, isDone, execute, watchVariables, unwatchVariables } = api;
 
       watchEffect(() => {
-        if (props.pause === true) {
-          pause();
+        if (props.watchVariables === true) {
+          unwatchVariables();
           return;
         }
 
-        resume();
+        watchVariables();
       });
 
       return () => {
@@ -67,9 +71,10 @@ export const Query = {
     }
 
     const queryProps = {
-      ...toRefs(props),
-      lazy: props.lazy,
-      cachePolicy: props.cachePolicy,
+      query: toRef(props, 'query') as Ref<string>,
+      variables: toRef(props, 'variables') as Ref<Record<string, any> | undefined>,
+      fetchOnMounted: props.fetchOnMount,
+      cachePolicy: props.cachePolicy as CachePolicy,
     };
 
     if (props.suspend) {

--- a/packages/villus/src/Query.ts
+++ b/packages/villus/src/Query.ts
@@ -1,19 +1,9 @@
-import { SetupContext, toRefs, watchEffect } from 'vue-demi';
-import { QueryComposable, useQuery } from './useQuery';
+import { defineComponent, Ref, toRef, watchEffect } from 'vue-demi';
 import { CachePolicy } from './types';
+import { QueryComposable, useQuery } from './useQuery';
 import { normalizeChildren } from './utils';
-import { DocumentNode } from 'graphql';
 
-interface QueryProps {
-  query: string | DocumentNode;
-  variables?: Record<string, any>;
-  cachePolicy?: CachePolicy;
-  lazy?: boolean;
-  pause?: boolean;
-  suspend?: boolean;
-}
-
-export const Query = {
+export const Query = defineComponent({
   name: 'Query',
   props: {
     query: {
@@ -27,11 +17,6 @@ export const Query = {
     cachePolicy: {
       type: String,
       default: undefined,
-      validator(value: string) {
-        const isValid = [undefined, 'cache-and-network', 'network-only', 'cache-first'].indexOf(value) !== -1;
-
-        return isValid;
-      },
     },
     watchVariables: {
       type: Boolean,
@@ -46,7 +31,7 @@ export const Query = {
       default: true,
     },
   },
-  setup(props: QueryProps, ctx: SetupContext) {
+  setup(props, ctx) {
     function createRenderFn(api: QueryComposable<unknown>) {
       const { data, error, isFetching, isDone, execute, watchVariables, unwatchVariables } = api;
 
@@ -83,4 +68,4 @@ export const Query = {
 
     return createRenderFn(useQuery(queryProps));
   },
-};
+});

--- a/packages/villus/src/Query.ts
+++ b/packages/villus/src/Query.ts
@@ -22,7 +22,7 @@ export const Query = defineComponent({
       type: Boolean,
       default: true,
     },
-    suspend: {
+    suspended: {
       type: Boolean,
       default: false,
     },
@@ -72,7 +72,7 @@ export const Query = defineComponent({
       cachePolicy: props.cachePolicy as CachePolicy,
     };
 
-    if (props.suspend) {
+    if (props.suspended) {
       return useQuery(queryProps).then(createRenderFn);
     }
 

--- a/packages/villus/src/Query.ts
+++ b/packages/villus/src/Query.ts
@@ -1,4 +1,4 @@
-import { defineComponent, Ref, toRef, watch, watchEffect } from 'vue-demi';
+import { defineComponent, Ref, toRef, watch } from 'vue-demi';
 import { CachePolicy } from './types';
 import { QueryComposable, useQuery } from './useQuery';
 import { normalizeChildren } from './utils';

--- a/packages/villus/src/Subscription.ts
+++ b/packages/villus/src/Subscription.ts
@@ -1,4 +1,4 @@
-import { defineComponent, watchEffect } from 'vue-demi';
+import { defineComponent, toRef, watch } from 'vue-demi';
 import { normalizeChildren } from './utils';
 import { useSubscription, defaultReducer, Reducer } from './useSubscription';
 
@@ -31,15 +31,17 @@ export const Subscription = defineComponent({
       (props.reduce as Reducer) || defaultReducer
     );
 
-    watchEffect(() => {
-      if (props.paused && !isPaused.value) {
+    watch(toRef(props, 'paused'), value => {
+      if (value === isPaused.value) {
+        return;
+      }
+
+      if (value) {
         pause();
         return;
       }
 
-      if (isPaused.value) {
-        resume();
-      }
+      resume();
     });
 
     return () => {

--- a/packages/villus/src/Subscription.ts
+++ b/packages/villus/src/Subscription.ts
@@ -1,15 +1,9 @@
-import { SetupContext } from 'vue-demi';
+import { defineComponent, SetupContext } from 'vue-demi';
 import { normalizeChildren } from './utils';
 import { useSubscription, defaultReducer, Reducer } from './useSubscription';
 import { DocumentNode } from 'graphql';
 
-interface SubscriptionProps {
-  query: string | DocumentNode;
-  variables?: Record<string, any>;
-  reduce?: Reducer;
-}
-
-export const Subscription = {
+export const Subscription = defineComponent({
   name: 'Subscription',
   props: {
     query: {
@@ -47,4 +41,4 @@ export const Subscription = {
       });
     };
   },
-};
+});

--- a/packages/villus/src/handleSubscriptions.ts
+++ b/packages/villus/src/handleSubscriptions.ts
@@ -1,0 +1,21 @@
+import { ClientPlugin, ClientPluginOperation, ObservableLike, OperationResult, QueryVariables } from './types';
+
+export type SubscriptionForwarder<TData = any, TVars = QueryVariables> = (
+  operation: ClientPluginOperation
+) => ObservableLike<OperationResult<TData>>;
+
+export function handleSubscriptions(forwarder: SubscriptionForwarder): ClientPlugin {
+  const forward = forwarder;
+
+  return function subscriptionsHandlerPlugin({ operation, useResult }) {
+    if (operation.type !== 'subscription') {
+      return;
+    }
+
+    if (!forward) {
+      throw new Error('No subscription forwarder was set.');
+    }
+
+    useResult(forward(operation) as any, true);
+  };
+}

--- a/packages/villus/src/index.ts
+++ b/packages/villus/src/index.ts
@@ -7,6 +7,7 @@ export { useClient } from './useClient';
 export { useQuery } from './useQuery';
 export { useMutation } from './useMutation';
 export { useSubscription } from './useSubscription';
+export { handleSubscriptions, SubscriptionForwarder } from './handleSubscriptions';
 export { fetch } from './fetch';
 export { cache } from './cache';
 export { ClientPlugin, ClientPluginContext, FetchOptions } from './types';

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -7,7 +7,7 @@ interface QueryCompositeOptions<TVars> {
   query: MaybeReactive<Operation['query']>;
   variables?: MaybeReactive<TVars>;
   cachePolicy?: CachePolicy;
-  lazy?: boolean;
+  fetchOnMount?: boolean;
 }
 
 interface QueryExecutionOpts {
@@ -125,8 +125,7 @@ function useQuery<TData = any, TVars = QueryVariables>(
 ): ThenableQueryComposable<TData> {
   const normalizedOpts = normalizeOptions(opts, variables);
   const api = _useQuery<TData, TVars>(normalizedOpts);
-  // Fetch on mounted if lazy is disabled.
-  if (!normalizedOpts.lazy) {
+  if (normalizedOpts.fetchOnMount) {
     onMounted(() => {
       api.execute();
     });
@@ -146,11 +145,19 @@ function normalizeOptions<TVars>(
   opts: QueryCompositeOptions<TVars> | QueryCompositeOptions<TVars>['query'],
   variables?: QueryCompositeOptions<TVars>['variables']
 ): QueryCompositeOptions<TVars> {
+  const defaultOpts = {
+    fetchOnMount: true,
+  };
+
   if (typeof opts !== 'string' && 'query' in opts) {
-    return opts;
+    return {
+      ...defaultOpts,
+      ...opts,
+    };
   }
 
   return {
+    ...defaultOpts,
     query: opts,
     variables,
   };

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -66,7 +66,7 @@ function _useQuery<TData, TVars>({
   }
 
   let stopVarsWatcher: ReturnType<typeof watch>;
-  const isWatchingVariables: Ref<boolean> = ref(false);
+  const isWatchingVariables: Ref<boolean> = ref(true);
 
   function beginWatchingVars() {
     let oldCache: number;
@@ -75,7 +75,7 @@ function _useQuery<TData, TVars>({
     }
 
     const watchableVars = toWatchableSource(variables);
-    isWatchingVariables.value = false;
+    isWatchingVariables.value = true;
     stopVarsWatcher = watch(
       watchableVars,
       newValue => {
@@ -93,14 +93,14 @@ function _useQuery<TData, TVars>({
   }
 
   function unwatchVariables() {
-    if (isWatchingVariables.value) return;
+    if (!isWatchingVariables.value) return;
 
     stopVarsWatcher();
-    isWatchingVariables.value = true;
+    isWatchingVariables.value = false;
   }
 
   function watchVariables() {
-    if (!isWatchingVariables.value) return;
+    if (isWatchingVariables.value) return;
 
     beginWatchingVars();
   }

--- a/packages/villus/src/utils/stringify.ts
+++ b/packages/villus/src/utils/stringify.ts
@@ -12,6 +12,7 @@ interface Options {
 }
 
 // https://github.com/epoberezkin/fast-json-stable-stringify/blob/master/index.js
+/* istanbul ignore next */
 export function stringify(data: any, opts?: Options | Comparator): string {
   if (!opts) opts = {};
   if (typeof opts === 'function') opts = { cmp: opts };

--- a/packages/villus/test/helpers/observer.ts
+++ b/packages/villus/test/helpers/observer.ts
@@ -28,5 +28,5 @@ export function makeObservable(throws = false) {
 }
 
 export function tick(ticks = 1) {
-  jest.advanceTimersByTime(ticks * 100);
+  jest.advanceTimersByTime(ticks * 100 + 1);
 }

--- a/packages/villus/test/query.spec.ts
+++ b/packages/villus/test/query.spec.ts
@@ -219,7 +219,7 @@ test('variables watcher can be disabled', async () => {
       <div>
         <Provider v-bind="client">
           <div>
-            <Query query="query fetchPost($id: ID!) { post (id: $id) { id title } }" :variables="{ id }" :pause="true" v-slot="{ data }">
+            <Query query="query fetchPost($id: ID!) { post (id: $id) { id title } }" :variables="{ id }" :watch-variables="true" v-slot="{ data }">
               <div v-if="data">
                 <h1>{{ data.post.title }}</h1>
               </div>

--- a/packages/villus/test/query.spec.ts
+++ b/packages/villus/test/query.spec.ts
@@ -219,7 +219,7 @@ test('variables watcher can be disabled', async () => {
       <div>
         <Provider v-bind="client">
           <div>
-            <Query query="query fetchPost($id: ID!) { post (id: $id) { id title } }" :variables="{ id }" :watch-variables="true" v-slot="{ data }">
+            <Query query="query fetchPost($id: ID!) { post (id: $id) { id title } }" :variables="{ id }" :watch-variables="false" v-slot="{ data }">
               <div v-if="data">
                 <h1>{{ data.post.title }}</h1>
               </div>

--- a/packages/villus/test/query.spec.ts
+++ b/packages/villus/test/query.spec.ts
@@ -288,9 +288,7 @@ test('variables prop arrangement does not trigger queries', async () => {
   expect(document.querySelector('h1')?.textContent).toContain('13');
 });
 
-// have no clue how to test this yet
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip('can be suspended', async () => {
+test('can be suspended', async () => {
   const client = {
     url: 'https://test.com/graphql',
   };

--- a/packages/villus/test/query.spec.ts
+++ b/packages/villus/test/query.spec.ts
@@ -201,7 +201,7 @@ test('variables are watched by default', async () => {
   expect(document.querySelector('h1')?.textContent).toContain('13');
 });
 
-test('variables watcher can be disabled', async () => {
+test('variables watcher can be disabled and enabled', async () => {
   const client = {
     url: 'https://test.com/graphql',
   };
@@ -210,6 +210,7 @@ test('variables watcher can be disabled', async () => {
     data: () => ({
       client,
       id: 12,
+      enabled: false,
     }),
     components: {
       Query,
@@ -219,12 +220,14 @@ test('variables watcher can be disabled', async () => {
       <div>
         <Provider v-bind="client">
           <div>
-            <Query query="query fetchPost($id: ID!) { post (id: $id) { id title } }" :variables="{ id }" :watch-variables="false" v-slot="{ data }">
+            <Query query="query fetchPost($id: ID!) { post (id: $id) { id title } }" :variables="{ id }" :watch-variables="enabled" v-slot="{ data }">
               <div v-if="data">
                 <h1>{{ data.post.title }}</h1>
               </div>
             </Query>
           </div>
+
+          <button @click="enabled = !enabled"></button>
         </Provider>
       </div>
     `,
@@ -237,6 +240,13 @@ test('variables watcher can be disabled', async () => {
   await flushPromises();
   expect(fetch).toHaveBeenCalledTimes(1);
   expect(document.querySelector('h1')?.textContent).toContain('12');
+  document.querySelector('button')?.click();
+  await flushPromises();
+  (vm as any).id = 14;
+  await flushPromises();
+
+  expect(fetch).toHaveBeenCalledTimes(2);
+  expect(document.querySelector('h1')?.textContent).toContain('14');
 });
 
 test('variables prop arrangement does not trigger queries', async () => {

--- a/packages/villus/test/query.spec.ts
+++ b/packages/villus/test/query.spec.ts
@@ -309,7 +309,7 @@ test.skip('can be suspended', async () => {
         <Provider v-bind="client">
           <Suspense>
             <template #default>
-              <Query query="{ posts { id title } }" v-slot="{ data }" suspend>
+              <Query query="{ posts { id title } }" v-slot="{ data }" suspended>
                 <ul>
                   <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
                 </ul>

--- a/packages/villus/test/subscription.spec.ts
+++ b/packages/villus/test/subscription.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from './helpers/mount';
 import flushPromises from 'flush-promises';
-import { Subscription, createClient, Provider } from '../src/index';
+import { Subscription, Provider } from '../src/index';
 import { makeObservable, tick } from './helpers/observer';
 
 beforeAll(() => {

--- a/packages/villus/test/subscription.spec.ts
+++ b/packages/villus/test/subscription.spec.ts
@@ -37,9 +37,52 @@ test('Handles subscriptions', async () => {
   });
 
   await flushPromises();
-  tick(5);
+  tick(4);
   await flushPromises();
-  expect(document.querySelector('span')?.textContent).toBe('4');
+  expect(document.querySelector('span')?.textContent).toBe('3');
+});
+
+test('can pause and resume subscriptions', async () => {
+  const client = {
+    url: 'https://test.com/graphql',
+    use: [handleSubscriptions(() => makeObservable()), ...defaultPlugins()],
+  };
+
+  const vm = mount({
+    data: () => ({
+      client,
+      paused: false,
+    }),
+    components: {
+      Subscription,
+      Provider,
+    },
+    template: `
+      <Provider v-bind="client">
+        <Subscription query="subscription { newMessages }" v-slot="{ data }" :paused="paused">
+          <div>
+            <span>{{ data && data.id }}</span>
+          </div>
+
+          <button @click="paused = !paused">Pause</button>
+        </Subscription>
+      </Provider>
+    `,
+  });
+
+  await flushPromises();
+  tick(3);
+  await flushPromises();
+  expect(document.querySelector('span')?.textContent).toBe('2');
+  document.querySelector('button')?.click();
+  await flushPromises();
+  tick(10);
+  expect(document.querySelector('span')?.textContent).toBe('2');
+  document.querySelector('button')?.click();
+  await flushPromises();
+  tick(7);
+  await flushPromises();
+  expect(document.querySelector('span')?.textContent).toBe('6');
 });
 
 test('Can provide a custom reducer', async () => {

--- a/packages/villus/test/subscription.spec.ts
+++ b/packages/villus/test/subscription.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from './helpers/mount';
 import flushPromises from 'flush-promises';
-import { Subscription, Provider } from '../src/index';
+import { Subscription, Provider, defaultPlugins, handleSubscriptions } from '../src/index';
 import { makeObservable, tick } from './helpers/observer';
 
 beforeAll(() => {
@@ -14,9 +14,7 @@ afterAll(() => {
 test('Handles subscriptions', async () => {
   const client = {
     url: 'https://test.com/graphql',
-    subscriptionForwarder: () => {
-      return makeObservable();
-    },
+    use: [handleSubscriptions(() => makeObservable()), ...defaultPlugins()],
   };
 
   mount({
@@ -38,6 +36,7 @@ test('Handles subscriptions', async () => {
     `,
   });
 
+  await flushPromises();
   tick(5);
   await flushPromises();
   expect(document.querySelector('span')?.textContent).toBe('4');
@@ -46,9 +45,7 @@ test('Handles subscriptions', async () => {
 test('Can provide a custom reducer', async () => {
   const client = {
     url: 'https://test.com/graphql',
-    subscriptionForwarder: () => {
-      return makeObservable();
-    },
+    use: [handleSubscriptions(() => makeObservable()), ...defaultPlugins()],
   };
 
   function reduce(oldMessages: string[], response: any) {
@@ -79,6 +76,8 @@ test('Can provide a custom reducer', async () => {
     `,
   });
 
+  await flushPromises();
+
   tick(5);
   await flushPromises();
   expect(document.querySelectorAll('li')).toHaveLength(5);
@@ -87,9 +86,7 @@ test('Can provide a custom reducer', async () => {
 test('Handles observer errors', async () => {
   const client = {
     url: 'https://test.com/graphql',
-    subscriptionForwarder: () => {
-      return makeObservable(true);
-    },
+    use: [handleSubscriptions(() => makeObservable(true)), ...defaultPlugins()],
   };
 
   mount({
@@ -110,6 +107,8 @@ test('Handles observer errors', async () => {
       </div>
     `,
   });
+
+  await flushPromises();
 
   tick(2);
   await flushPromises();

--- a/packages/villus/test/useQuery.spec.ts
+++ b/packages/villus/test/useQuery.spec.ts
@@ -344,12 +344,12 @@ test('variables watcher can be disabled', async () => {
         id: 12,
       });
 
-      const { data, pause, isPaused, resume } = useQuery({
+      const { data, unwatchVariables, isWatchingVariables, watchVariables } = useQuery({
         query: 'query fetchPost($id: ID!) { post (id: $id) { id title } }',
         variables,
       });
 
-      return { data, variables, pause, resume, isPaused };
+      return { data, variables, unwatchVariables, watchVariables, isWatchingVariables };
     },
     template: `
     <div>
@@ -357,8 +357,8 @@ test('variables watcher can be disabled', async () => {
         <h1>{{ data.post.title }}</h1>
       </div>
       <button id="change" @click="variables.id = variables.id + 1"></button>
-      <button id="toggle" @click="isPaused ? resume() : pause()"></button>
-      <span id="status">{{ isPaused }}</span>
+      <button id="toggle" @click="isWatchingVariables ? watchVariables() : unwatchVariables()"></button>
+      <span id="status">{{ isWatchingVariables }}</span>
     </div>`,
   });
 

--- a/packages/villus/test/useQuery.spec.ts
+++ b/packages/villus/test/useQuery.spec.ts
@@ -6,441 +6,442 @@ import flushPromises from 'flush-promises';
 import { useClient, useQuery } from '../src/index';
 import { Post } from './server/typedSchema';
 
-test('executes hook queries on mounted', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
+describe('useQuery()', () => {
+  test('executes hook queries on mounted', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-      const { data, error } = useQuery<{ posts: Post[] }>('{ posts { id title } }');
+        const { data, error } = useQuery<{ posts: Post[] }>('{ posts { id title } }');
 
-      return { data, error };
-    },
-    template: `
+        return { data, error };
+      },
+      template: `
     <div>'
       <div>{{ error }}</div>
       <ul v-if="data">
         <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
       </ul>
     </div>`,
+    });
+
+    await flushPromises();
+
+    expect(document.querySelectorAll('li').length).toBe(5);
   });
 
-  await flushPromises();
+  test('alternate signature', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  expect(document.querySelectorAll('li').length).toBe(5);
-});
+        const { data, error } = useQuery<{ posts: Post[] }>('{ posts { id title } }');
 
-test('alternate signature', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-
-      const { data, error } = useQuery<{ posts: Post[] }>('{ posts { id title } }');
-
-      return { data, error };
-    },
-    template: `
+        return { data, error };
+      },
+      template: `
     <div>'
       <div>{{ error }}</div>
       <ul v-if="data">
         <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
       </ul>
     </div>`,
+    });
+
+    await flushPromises();
+
+    expect(document.querySelectorAll('li').length).toBe(5);
   });
 
-  await flushPromises();
+  test('works with tagged queries', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  expect(document.querySelectorAll('li').length).toBe(5);
-});
-
-test('works with tagged queries', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-
-      const { data } = useQuery({
-        query: gql`
-          {
-            posts {
-              id
-              title
+        const { data } = useQuery({
+          query: gql`
+            {
+              posts {
+                id
+                title
+              }
             }
-          }
-        `,
-      });
+          `,
+        });
 
-      return { data };
-    },
-    template: `
+        return { data };
+      },
+      template: `
     <div>
       <ul v-if="data">
         <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
       </ul>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(document.querySelectorAll('li').length).toBe(5);
   });
 
-  await flushPromises();
-  expect(document.querySelectorAll('li').length).toBe(5);
-});
+  test('caches queries by default', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-test('caches queries by default', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
+        const { data, execute } = useQuery({ query: '{ posts { id title } }' });
 
-      const { data, execute } = useQuery({ query: '{ posts { id title } }' });
-
-      return { data, execute };
-    },
-    template: `
+        return { data, execute };
+      },
+      template: `
     <div>
       <ul v-if="data">
         <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
       </ul>
       <button @click="execute()"></button>
     </div>`,
+    });
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+    await flushPromises();
+    // cache was used.
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
 
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
-  await flushPromises();
-  // cache was used.
-  expect(fetch).toHaveBeenCalledTimes(1);
-});
+  test('re-runs reactive queries automatically', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-test('re-runs reactive queries automatically', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
+        const id = ref(12);
+        const query = computed(() => {
+          return `{ post (id: ${id.value}) { id title } }`;
+        });
 
-      const id = ref(12);
-      const query = computed(() => {
-        return `{ post (id: ${id.value}) { id title } }`;
-      });
+        const { data } = useQuery({
+          query,
+        });
 
-      const { data } = useQuery({
-        query,
-      });
-
-      return { data, id };
-    },
-    template: `
+        return { data, id };
+      },
+      template: `
     <div>
       <div v-if="data">
         <h1>{{ data.post.title }}</h1>
       </div>
       <button @click="id = 13"></button>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('h1')?.textContent).toContain('12');
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+
+    await flushPromises();
+    // fetch was triggered a second time, due to variable change.
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('h1')?.textContent).toContain('13');
   });
 
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('h1')?.textContent).toContain('12');
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
+  test('cache policy can be overridden with execute function', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  await flushPromises();
-  // fetch was triggered a second time, due to variable change.
-  expect(fetch).toHaveBeenCalledTimes(2);
-  expect(document.querySelector('h1')?.textContent).toContain('13');
-});
+        const { data, execute } = useQuery({ query: '{ posts { id title } }' });
 
-test('cache policy can be overridden with execute function', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-
-      const { data, execute } = useQuery({ query: '{ posts { id title } }' });
-
-      return { data, execute };
-    },
-    template: `
+        return { data, execute };
+      },
+      template: `
     <div>
       <ul v-if="data">
         <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
       </ul>
       <button @click="execute({ cachePolicy: 'cache-and-network' })"></button>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+    await flushPromises();
+    // fetch was triggered a second time.
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
+  test('cache policy can be overridden with cachePolicy option', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
-  await flushPromises();
-  // fetch was triggered a second time.
-  expect(fetch).toHaveBeenCalledTimes(2);
-});
+        const { data, execute } = useQuery({ query: '{ posts { id title } }', cachePolicy: 'cache-and-network' });
 
-test('cache policy can be overridden with cachePolicy option', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-
-      const { data, execute } = useQuery({ query: '{ posts { id title } }', cachePolicy: 'cache-and-network' });
-
-      return { data, execute };
-    },
-    template: `
+        return { data, execute };
+      },
+      template: `
     <div>
       <ul v-if="data">
         <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
       </ul>
       <button @click="execute()"></button>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+    await flushPromises();
+    // fetch was triggered a second time.
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
+  test('variables are watched by default if refs', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
-  await flushPromises();
-  // fetch was triggered a second time.
-  expect(fetch).toHaveBeenCalledTimes(2);
-});
+        const variables = ref({
+          id: 12,
+        });
 
-test('variables are watched by default if refs', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
+        const { data } = useQuery({
+          query: 'query fetchPost($id: ID!) { post (id: $id) { id title } }',
+          variables,
+        });
 
-      const variables = ref({
-        id: 12,
-      });
-
-      const { data } = useQuery({
-        query: 'query fetchPost($id: ID!) { post (id: $id) { id title } }',
-        variables,
-      });
-
-      return { data, variables };
-    },
-    template: `
+        return { data, variables };
+      },
+      template: `
     <div>
       <div v-if="data">
         <h1>{{ data.post.title }}</h1>
       </div>
       <button @click="variables.id = 13"></button>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('h1')?.textContent).toContain('12');
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+
+    await flushPromises();
+    // fetch was triggered a second time, due to variable change.
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('h1')?.textContent).toContain('13');
   });
 
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('h1')?.textContent).toContain('12');
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
+  test('variables are watched by default if reactive', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  await flushPromises();
-  // fetch was triggered a second time, due to variable change.
-  expect(fetch).toHaveBeenCalledTimes(2);
-  expect(document.querySelector('h1')?.textContent).toContain('13');
-});
+        const variables = reactive({
+          id: 12,
+        });
 
-test('variables are watched by default if reactive', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
+        const { data } = useQuery('query fetchPost($id: ID!) { post (id: $id) { id title } }', variables);
 
-      const variables = reactive({
-        id: 12,
-      });
-
-      const { data } = useQuery('query fetchPost($id: ID!) { post (id: $id) { id title } }', variables);
-
-      return { data, variables };
-    },
-    template: `
+        return { data, variables };
+      },
+      template: `
     <div>
       <div v-if="data">
         <h1>{{ data.post.title }}</h1>
       </div>
       <button @click="variables.id = 13"></button>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('h1')?.textContent).toContain('12');
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+
+    await flushPromises();
+    // fetch was triggered a second time, due to variable change.
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('h1')?.textContent).toContain('13');
   });
 
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('h1')?.textContent).toContain('12');
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
+  test('cached variables are matched by equality not reference', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  await flushPromises();
-  // fetch was triggered a second time, due to variable change.
-  expect(fetch).toHaveBeenCalledTimes(2);
-  expect(document.querySelector('h1')?.textContent).toContain('13');
-});
+        const variables = ref({
+          id: 12,
+        });
 
-test('cached variables are matched by equality not reference', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
+        const { data } = useQuery({
+          query: 'query fetchPost($id: ID!) { post (id: $id) { id title } }',
+          variables,
+        });
 
-      const variables = ref({
-        id: 12,
-      });
+        function updateRef() {
+          variables.value = { id: 12 };
+        }
 
-      const { data } = useQuery({
-        query: 'query fetchPost($id: ID!) { post (id: $id) { id title } }',
-        variables,
-      });
-
-      function updateRef() {
-        variables.value = { id: 12 };
-      }
-
-      return { data, variables, updateRef };
-    },
-    template: `
+        return { data, variables, updateRef };
+      },
+      template: `
     <div>
       <div v-if="data">
         <h1>{{ data.post.title }}</h1>
       </div>
       <button @click="updateRef"></button>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('h1')?.textContent).toContain('12');
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+
+    await flushPromises();
+    // fetch was triggered a second time, due to variable change.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('h1')?.textContent).toContain('12');
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+
+    await flushPromises();
+    // fetch was triggered a second time, due to variable change.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('h1')?.textContent).toContain('12');
   });
 
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('h1')?.textContent).toContain('12');
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
+  test('variables watcher can be disabled', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  await flushPromises();
-  // fetch was triggered a second time, due to variable change.
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('h1')?.textContent).toContain('12');
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
+        const variables = ref({
+          id: 12,
+        });
 
-  await flushPromises();
-  // fetch was triggered a second time, due to variable change.
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('h1')?.textContent).toContain('12');
-});
+        const { data, unwatchVariables, isWatchingVariables, watchVariables } = useQuery({
+          query: 'query fetchPost($id: ID!) { post (id: $id) { id title } }',
+          variables,
+        });
 
-test('variables watcher can be disabled', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-
-      const variables = ref({
-        id: 12,
-      });
-
-      const { data, unwatchVariables, isWatchingVariables, watchVariables } = useQuery({
-        query: 'query fetchPost($id: ID!) { post (id: $id) { id title } }',
-        variables,
-      });
-
-      return { data, variables, unwatchVariables, watchVariables, isWatchingVariables };
-    },
-    template: `
+        return { data, variables, unwatchVariables, watchVariables, isWatchingVariables };
+      },
+      template: `
     <div>
       <div v-if="data">
         <h1>{{ data.post.title }}</h1>
       </div>
       <button id="change" @click="variables.id = variables.id + 1"></button>
-      <button id="toggle" @click="isWatchingVariables ? watchVariables() : unwatchVariables()"></button>
+      <button id="toggle" @click="isWatchingVariables ? unwatchVariables() : watchVariables()"></button>
       <span id="status">{{ isWatchingVariables }}</span>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('h1')?.textContent).toContain('12');
+    document.querySelector('#toggle')?.dispatchEvent(new Event('click'));
+    document.querySelector('#change')?.dispatchEvent(new Event('click'));
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('h1')?.textContent).toContain('12');
+    expect(document.querySelector('#status')?.textContent).toContain('false');
+
+    // toggle it back
+    document.querySelector('#toggle')?.dispatchEvent(new Event('click'));
+    document.querySelector('#change')?.dispatchEvent(new Event('click'));
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('h1')?.textContent).toContain('14');
+    expect(document.querySelector('#status')?.textContent).toContain('true');
   });
 
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('h1')?.textContent).toContain('12');
-  document.querySelector('#toggle')?.dispatchEvent(new Event('click'));
-  document.querySelector('#change')?.dispatchEvent(new Event('click'));
+  test('variables prop arrangement does not trigger queries', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('h1')?.textContent).toContain('12');
-  expect(document.querySelector('#status')?.textContent).toContain('true');
+        const variables = ref({
+          id: 12,
+          type: 'test',
+        });
 
-  // toggle it back
-  document.querySelector('#toggle')?.dispatchEvent(new Event('click'));
-  document.querySelector('#change')?.dispatchEvent(new Event('click'));
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(2);
-  expect(document.querySelector('h1')?.textContent).toContain('14');
-  expect(document.querySelector('#status')?.textContent).toContain('false');
-});
+        const { data } = useQuery({
+          query: 'query fetchPost($id: ID!) { post (id: $id) { id title } }',
+          variables,
+        });
 
-test('variables prop arrangement does not trigger queries', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-
-      const variables = ref({
-        id: 12,
-        type: 'test',
-      });
-
-      const { data } = useQuery({
-        query: 'query fetchPost($id: ID!) { post (id: $id) { id title } }',
-        variables,
-      });
-
-      return { data, variables };
-    },
-    template: `
+        return { data, variables };
+      },
+      template: `
     <div>
       <div v-if="data">
         <h1>{{ data.post.title }}</h1>
       </div>
       <button @click="variables = { type: 'test', id: 12 }"></button>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('h1')?.textContent).toContain('12');
+
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('h1')?.textContent).toContain('12');
+  test('can be suspended', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
+      },
+      components: {
+        Listing: {
+          async setup() {
+            const { data } = await useQuery({ query: '{ posts { id title } }' });
 
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
-});
-
-test('can be suspended', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-    },
-    components: {
-      Listing: {
-        async setup() {
-          const { data } = await useQuery({ query: '{ posts { id title } }' });
-
-          return { data };
-        },
-        template: `
+            return { data };
+          },
+          template: `
           <ul>
             <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
           </ul>
         `,
+        },
       },
-    },
-    template: `
+      template: `
       <div>
         <Suspense>
           <template #default>
@@ -451,251 +452,252 @@ test('can be suspended', async () => {
           </template>
         </Suspense>
       </div>`,
+    });
+
+    expect(document.body.textContent).toBe('Loading...');
+    await flushPromises();
+    expect(document.querySelectorAll('li').length).toBe(5);
   });
 
-  expect(document.body.textContent).toBe('Loading...');
-  await flushPromises();
-  expect(document.querySelectorAll('li').length).toBe(5);
-});
-
-test('Handles query errors', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-
-      const { data, error } = useQuery({
-        query: '{ posts { id title propNotFound } }',
-      });
-
-      return { data, error };
-    },
-    template: `
-    <div>
-      <div v-if="data">
-        <h1>It shouldn't work!</h1>
-      </div>
-      <p id="error" v-if="error">{{ error.message }}</p>
-    </div>`,
-  });
-
-  await flushPromises();
-  expect(document.querySelector('#error')?.textContent).toMatch(/Cannot query field/);
-});
-
-test('Handles parse errors', async () => {
-  (global as any).fetchController.simulateParseError = true;
-
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-
-      const { data, error } = useQuery({
-        query: '{ posts { id title } }',
-      });
-
-      return { data, error };
-    },
-    template: `
-    <div>
-      <div v-if="data">
-        <h1>It shouldn't work!</h1>
-      </div>
-      <p id="error" v-if="error">{{ error.message }}</p>
-    </div>`,
-  });
-
-  await flushPromises();
-  expect(document.querySelector('#error')?.textContent).toMatch(/Error parsing/);
-});
-
-test('Handles network errors', async () => {
-  (global as any).fetchController.simulateNetworkError = true;
-
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
-
-      const { data, error } = useQuery({
-        query: '{ posts { id title } }',
-      });
-
-      return { data, error };
-    },
-    template: `
-    <div>
-      <div v-if="data">
-        <h1>It shouldn't work!</h1>
-      </div>
-      <p id="error" v-if="error">{{ error.message }}</p>
-    </div>`,
-  });
-
-  await flushPromises();
-  expect(document.querySelector('#error')?.textContent).toMatch(/Network Error/);
-});
-
-test('Fails if provider was not resolved', () => {
-  try {
+  test('Handles query errors', async () => {
     mount({
       setup() {
-        const { data, error } = useQuery({ query: `{ posts { id title } }` });
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-        return { messages: data, error };
+        const { data, error } = useQuery({
+          query: '{ posts { id title propNotFound } }',
+        });
+
+        return { data, error };
       },
       template: `
+    <div>
+      <div v-if="data">
+        <h1>It shouldn't work!</h1>
+      </div>
+      <p id="error" v-if="error">{{ error.message }}</p>
+    </div>`,
+    });
+
+    await flushPromises();
+    expect(document.querySelector('#error')?.textContent).toMatch(/Cannot query field/);
+  });
+
+  test('Handles parse errors', async () => {
+    (global as any).fetchController.simulateParseError = true;
+
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
+
+        const { data, error } = useQuery({
+          query: '{ posts { id title } }',
+        });
+
+        return { data, error };
+      },
+      template: `
+    <div>
+      <div v-if="data">
+        <h1>It shouldn't work!</h1>
+      </div>
+      <p id="error" v-if="error">{{ error.message }}</p>
+    </div>`,
+    });
+
+    await flushPromises();
+    expect(document.querySelector('#error')?.textContent).toMatch(/Error parsing/);
+  });
+
+  test('Handles network errors', async () => {
+    (global as any).fetchController.simulateNetworkError = true;
+
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
+
+        const { data, error } = useQuery({
+          query: '{ posts { id title } }',
+        });
+
+        return { data, error };
+      },
+      template: `
+    <div>
+      <div v-if="data">
+        <h1>It shouldn't work!</h1>
+      </div>
+      <p id="error" v-if="error">{{ error.message }}</p>
+    </div>`,
+    });
+
+    await flushPromises();
+    expect(document.querySelector('#error')?.textContent).toMatch(/Network Error/);
+  });
+
+  test('Fails if provider was not resolved', () => {
+    try {
+      mount({
+        setup() {
+          const { data, error } = useQuery({ query: `{ posts { id title } }` });
+
+          return { messages: data, error };
+        },
+        template: `
       <div>
         <ul v-if="data">
           <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
         </ul>
       </div>
     `,
-    });
-  } catch (err) {
-    // eslint-disable-next-line jest/no-try-expect, jest/no-conditional-expect
-    expect(err.message).toContain('Cannot detect villus Client');
-  }
-});
-
-test('Errors are stringified nicely to their messages', async () => {
-  (global as any).fetchController.simulateNetworkError = true;
-
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
       });
+    } catch (err) {
+      // eslint-disable-next-line jest/no-try-expect, jest/no-conditional-expect
+      expect(err.message).toContain('Cannot detect villus Client');
+    }
+  });
 
-      const { data, error } = useQuery({
-        query: '{ posts { id title } }',
-      });
+  test('Errors are stringified nicely to their messages', async () => {
+    (global as any).fetchController.simulateNetworkError = true;
 
-      return { data, error };
-    },
-    template: `
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
+
+        const { data, error } = useQuery({
+          query: '{ posts { id title } }',
+        });
+
+        return { data, error };
+      },
+      template: `
     <div>
       <div v-if="data">
         <h1>It shouldn't work!</h1>
       </div>
       <p id="error" v-if="error">{{ error.toString() }}</p>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(document.querySelector('#error')?.textContent).toMatch(/Network Error/);
   });
 
-  await flushPromises();
-  expect(document.querySelector('#error')?.textContent).toMatch(/Network Error/);
-});
+  test('Errors can be separated by type', async () => {
+    (global as any).fetchController.simulateNetworkError = true;
 
-test('Errors can be separated by type', async () => {
-  (global as any).fetchController.simulateNetworkError = true;
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
+        const { data, error } = useQuery({
+          query: '{ posts { id title } }',
+        });
 
-      const { data, error } = useQuery({
-        query: '{ posts { id title } }',
-      });
-
-      return { data, error };
-    },
-    template: `
+        return { data, error };
+      },
+      template: `
     <div>
       <div v-if="data">
         <h1>It shouldn't work!</h1>
       </div>
       <p id="error" v-if="error">{{ error.isGraphQLError ? 'GraphQL' : 'Network' }}</p>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(document.querySelector('#error')?.textContent).toBe('Network');
   });
 
-  await flushPromises();
-  expect(document.querySelector('#error')?.textContent).toBe('Network');
-});
+  // # 49
+  test('Errors can have non 200 response code', async () => {
+    (global as any).fetchController.simulateNetworkErrorWithGraphQLResponse = true;
 
-// # 49
-test('Errors can have non 200 response code', async () => {
-  (global as any).fetchController.simulateNetworkErrorWithGraphQLResponse = true;
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
+        const { data, error } = useQuery({
+          query: '{ posts { id title } }',
+        });
 
-      const { data, error } = useQuery({
-        query: '{ posts { id title } }',
-      });
-
-      return { data, error };
-    },
-    template: `
+        return { data, error };
+      },
+      template: `
     <div>
       <div v-if="data">
         <h1>It shouldn't work!</h1>
       </div>
       <p id="error" v-if="error">{{ error.isGraphQLError ? 'GraphQL' : 'Network' }}</p>
     </div>`,
+    });
+
+    await flushPromises();
+    expect(document.querySelector('#error')?.textContent).toBe('GraphQL');
   });
 
-  await flushPromises();
-  expect(document.querySelector('#error')?.textContent).toBe('GraphQL');
-});
+  test('cache-only policy returns null results if not found', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+          cachePolicy: 'cache-only',
+        });
 
-test('cache-only policy returns null results if not found', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-        cachePolicy: 'cache-only',
-      });
+        const { data, execute } = useQuery({ query: '{ posts { id title } }' });
 
-      const { data, execute } = useQuery({ query: '{ posts { id title } }' });
-
-      return { data, execute };
-    },
-    template: `
+        return { data, execute };
+      },
+      template: `
     <div>
       <ul v-if="data">
         <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
       </ul>
     </div>`,
+    });
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(0);
+    expect(document.querySelector('ul')).toBeNull();
   });
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(0);
-  expect(document.querySelector('ul')).toBeNull();
-});
 
-test('cache-only policy returns results if found in cache', async () => {
-  mount({
-    setup() {
-      useClient({
-        url: 'https://test.com/graphql',
-      });
+  test('cache-only policy returns results if found in cache', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
 
-      const { data, execute } = useQuery({ query: '{ posts { id title } }' });
+        const { data, execute } = useQuery({ query: '{ posts { id title } }' });
 
-      return { data, execute };
-    },
-    template: `
+        return { data, execute };
+      },
+      template: `
     <div>
       <ul v-if="data">
         <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
       </ul>
       <button @click="execute({ cachePolicy: 'cache-only' })"></button>
     </div>`,
-  });
-  await flushPromises();
-  expect(fetch).toHaveBeenCalledTimes(1);
+    });
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(1);
 
-  document.querySelector('button')?.dispatchEvent(new Event('click'));
-  await flushPromises();
-  // cache was used.
-  expect(fetch).toHaveBeenCalledTimes(1);
-  expect(document.querySelector('ul')?.children).toHaveLength(5);
+    document.querySelector('button')?.dispatchEvent(new Event('click'));
+    await flushPromises();
+    // cache was used.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('ul')?.children).toHaveLength(5);
+  });
 });

--- a/packages/villus/test/useSubscription.spec.ts
+++ b/packages/villus/test/useSubscription.spec.ts
@@ -2,7 +2,7 @@
 import flushPromises from 'flush-promises';
 import { mount } from './helpers/mount';
 import { makeObservable } from './helpers/observer';
-import { useClient, useSubscription } from '../src/index';
+import { defaultPlugins, handleSubscriptions, useClient, useSubscription } from '../src/index';
 
 jest.useFakeTimers();
 
@@ -16,9 +16,7 @@ test('Default reducer', async () => {
     setup() {
       useClient({
         url: 'https://test.com/graphql',
-        subscriptionForwarder: () => {
-          return makeObservable();
-        },
+        use: [handleSubscriptions(() => makeObservable()), ...defaultPlugins()],
       });
 
       const { data } = useSubscription<Message>({ query: `subscription { newMessages }` });
@@ -34,6 +32,7 @@ test('Default reducer', async () => {
     `,
   });
 
+  await flushPromises();
   jest.advanceTimersByTime(501);
   await flushPromises();
   expect(document.querySelector('span')?.textContent).toBe('4');
@@ -44,9 +43,7 @@ test('Handles subscriptions with a custom reducer', async () => {
     setup() {
       useClient({
         url: 'https://test.com/graphql',
-        subscriptionForwarder: () => {
-          return makeObservable();
-        },
+        use: [handleSubscriptions(() => makeObservable()), ...defaultPlugins()],
       });
 
       const { data } = useSubscription<Message, string[]>(
@@ -71,6 +68,7 @@ test('Handles subscriptions with a custom reducer', async () => {
     `,
   });
 
+  await flushPromises();
   jest.advanceTimersByTime(501);
   await flushPromises();
   expect(document.querySelectorAll('li')).toHaveLength(5);
@@ -81,9 +79,7 @@ test('Handles observer errors', async () => {
     setup() {
       useClient({
         url: 'https://test.com/graphql',
-        subscriptionForwarder: () => {
-          return makeObservable(true);
-        },
+        use: [handleSubscriptions(() => makeObservable(true)), ...defaultPlugins()],
       });
 
       function reduce(oldMessages: string[] | null, response: any): string[] {
@@ -108,6 +104,7 @@ test('Handles observer errors', async () => {
     `,
   });
 
+  await flushPromises();
   jest.advanceTimersByTime(150);
   await flushPromises();
   expect(document.querySelector('#error')?.textContent).toContain('oops!');
@@ -118,9 +115,7 @@ test('Pauses and resumes subscriptions', async () => {
     setup() {
       useClient({
         url: 'https://test.com/graphql',
-        subscriptionForwarder: () => {
-          return makeObservable();
-        },
+        use: [handleSubscriptions(() => makeObservable()), ...defaultPlugins()],
       });
 
       function reduce(oldMessages: string[] | null, response: any) {
@@ -155,6 +150,7 @@ test('Pauses and resumes subscriptions', async () => {
   expect(document.querySelectorAll('li')).toHaveLength(2);
   expect(document.querySelector('#status')?.textContent).toBe('true');
   document.querySelector('button')?.dispatchEvent(new Event('click'));
+  await flushPromises();
   jest.advanceTimersByTime(201);
   await flushPromises();
 

--- a/packages/villus/test/useSubscription.spec.ts
+++ b/packages/villus/test/useSubscription.spec.ts
@@ -187,6 +187,7 @@ test('Fails if subscription forwarder was not set', () => {
       setup() {
         useClient({
           url: 'https://test.com/graphql',
+          use: [handleSubscriptions(null as any)],
         });
         const { data, error } = useSubscription({ query: `subscription { newMessages }` });
 


### PR DESCRIPTION
This PR contains minor but breaking changes, mostly prop names have been changed to have better and easier meaning.

- `lazy` prop on `useQuery` and `Query` has been renamed to `fetchOnMount` to better communicate the purpose.
- Changed the `pausing` terminology for `useQuery` and `Query` to better reflect their use, `resume` is now `watchVariables` and `pause` is now `unwatchVariables`, `isPaused` is now `isWatchingVariables`. A little verbose but clear cut.
- renamed `pause` prop name to be `paused` on both `Query` and `Subscription` components
- renamed `suspend` prop on `Query` component to `suspended` for consistency with other props.
- subscriptions have been re-implemented as a simple plugin rather than their own weird thing.