### PR TITLE
feat: support `TypedDocumentNode`

### DIFF
--- a/docs/components/global/Codesandbox.vue
+++ b/docs/components/global/Codesandbox.vue
@@ -1,0 +1,36 @@
+<template>
+  <iframe
+    :src="src"
+    style="width: 100%; height: 500px; border: 0; border-radius: 4px; overflow: hidden; margin-top: 40px"
+    :title="title"
+    allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+    sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+  ></iframe>
+</template>
+
+<script>
+export default {
+  name: 'Codesandbox',
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    title: {
+      type: String,
+      required: true,
+    },
+    view: {
+      type: String,
+      default: undefined,
+    },
+  },
+  computed: {
+    src() {
+      return `https://codesandbox.io/embed/${this.id}?fontsize=14&hidenavigation=1&theme=${this.$store.state.theme}${
+        this.view ? '&view=' + this.view : ''
+      }`;
+    },
+  },
+};
+</script>

--- a/docs/content/guide/typescript-codgen.md
+++ b/docs/content/guide/typescript-codgen.md
@@ -1,0 +1,95 @@
+---
+title: GraphQL Code Generator Workflow
+description: How to use GraphQL code generator with villus
+order: 7
+---
+
+# GraphQL Code Generator Workflow
+
+`villus` is built with TypeScript in its core, you can provide typings for your fetched queries and their variables.
+
+Providing typings manually for your queries and variables can be as straight forward as this:
+
+```ts
+import { useQuery } from 'villus';
+
+interface PostsQuery {
+  posts: {
+    id: number;
+    title: string;
+  };
+}
+
+interface PostsVariables {
+  first?: number;
+  after?: number;
+}
+
+const { data } = useQuery<PostsQuery, PostsVariables>({
+  query: `{
+    posts {
+      id
+      title
+    }
+  }`,
+  variables: {
+    // variables are now typed as PostsVariables
+  },
+});
+
+data.value; // is now typed as PostsQuery type!
+```
+
+This however simple it is, it can be very tedious and will be hard to maintain as your schema evolve with time. Which is why it is better to automatically generate them with [GraphQL code generator](https://graphql-code-generator.com/).
+
+## Automatically Generating Types
+
+The [GraphQL code generator](https://graphql-code-generator.com/) tool allow you to configure automation to generate the TypeScript definitions for your schema, queries, mutations and their variables.
+
+Make to read their [documentation](https://graphql-code-generator.com/docs/getting-started/index) to get familiar with the setup and tools you will need, this guide will focus on the relevant parts of `villus`.
+
+### Using Generated Queries
+
+Once you've got everything setup, you will be able to import your queries and their type definitions along with their variables as well, the following is a snippet of such a setup:
+
+```ts
+import { useQuery } from 'villus';
+import { Posts, PostsQuery, PostsQueryVariables } from '@/graphql/Posts.gql';
+
+const { data } = useQuery<PostsQuery, PostsQueryVariables>({
+  query: Posts
+  variables: {
+    // variables are now typed as PostsQueryVariables
+  },
+});
+
+data.value; // is now typed as PostsQuery type!
+```
+
+### Using Typed Document
+
+There is a nice plugin for the code generator called [Typed Document Node](https://graphql-code-generator.com/docs/plugins/typed-document-node/) that instead of generating just types for your queries, it generates a `TypedDocumentNode` that has both the type information of your queries/mutations and their variables, so you don't need to import the query type each time you use villus.
+
+After setting up the plugin and generating the required files you can now import the new `TypedDocumented` for your queries, here is a sample:
+
+```ts
+import { useQuery } from 'villus';
+import { PostsDocument } from '@/graphql/Posts';
+
+const { data } = useQuery({
+  query: PostsDocument
+  variables: {
+    // variables are now typed as PostsQueryVariables
+  },
+});
+
+data.value; // is now typed as PostsQuery type!
+```
+
+This reduces the noise you have to import in your file and allow your code to be more concise.
+
+## Demo
+
+Here is a live example of a project with the complete setup of the mentioned tools in a Nuxt app:
+
+<codesandbox title="Villus + Nuxt + TypedDocument Plugin" id="villus-nuxt-typeddocument-plugin-qewsn"></codesandbox>

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
+    "@graphql-typed-document-node/core": "^3.1.0",
     "@types/graphql": "^14.5.0",
     "@types/graphql-upload": "^8.0.4",
     "@types/jest": "^26.0.14",

--- a/packages/villus/src/cache.ts
+++ b/packages/villus/src/cache.ts
@@ -1,10 +1,10 @@
-import { OperationResult, Operation, ClientPlugin, QueryVariables, CachePolicy, ClientPluginOperation } from './types';
+import { OperationResult, Operation, ClientPlugin, CachePolicy, ClientPluginOperation } from './types';
 
 interface ResultCache {
   [k: string]: OperationResult;
 }
 
-export interface CachedOperation<TVars = QueryVariables> extends Operation<TVars> {
+export interface OperationWithCachePolicy<TData, TVars> extends Operation<TData, TVars> {
   cachePolicy?: CachePolicy;
 }
 

--- a/packages/villus/src/client.ts
+++ b/packages/villus/src/client.ts
@@ -1,4 +1,4 @@
-import { cache, CachedOperation } from './cache';
+import { cache, OperationWithCachePolicy } from './cache';
 import { DEFAULT_FETCH_OPTS, getQueryKey } from './utils';
 import {
   OperationResult,
@@ -39,7 +39,7 @@ export class Client {
    * Executes an operation and returns a normalized response.
    */
   private async execute<TData, TVars>(
-    operation: Operation<TVars> | CachedOperation<TVars>,
+    operation: Operation<TData, TVars> | OperationWithCachePolicy<TData, TVars>,
     type: OperationType
   ): Promise<OperationResult<TData>> {
     let result: OperationResult<TData> | undefined;
@@ -108,18 +108,18 @@ export class Client {
   }
 
   public async executeQuery<TData = any, TVars = QueryVariables>(
-    operation: CachedOperation<TVars>
+    operation: OperationWithCachePolicy<TData, TVars>
   ): Promise<OperationResult> {
     return this.execute<TData, TVars>(operation, 'query');
   }
 
   public async executeMutation<TData = any, TVars = QueryVariables>(
-    operation: Operation<TVars>
+    operation: Operation<TData, TVars>
   ): Promise<OperationResult> {
     return this.execute<TData, TVars>(operation, 'mutation');
   }
 
-  public async executeSubscription<TData = any, TVars = QueryVariables>(operation: Operation<TVars>) {
+  public async executeSubscription<TData = any, TVars = QueryVariables>(operation: Operation<TData, TVars>) {
     const result = await this.execute<TData, TVars>(operation, 'subscription');
 
     return (result as unknown) as ObservableLike<OperationResult<TData>>;

--- a/packages/villus/src/fetch.ts
+++ b/packages/villus/src/fetch.ts
@@ -61,7 +61,7 @@ export function fetch(opts?: FetchPluginOpts): ClientPlugin {
   };
 }
 
-export function makeFetchOptions({ query, variables }: Operation<unknown>, opts: FetchOptions) {
+export function makeFetchOptions({ query, variables }: Operation<unknown, unknown>, opts: FetchOptions) {
   const normalizedQuery = normalizeQuery(query);
   if (!normalizedQuery) {
     throw new Error('A query must be provided.');

--- a/packages/villus/src/types.ts
+++ b/packages/villus/src/types.ts
@@ -1,7 +1,8 @@
 import { Ref } from 'vue-demi';
 import { DocumentNode } from 'graphql';
 import { CombinedError } from './utils';
-import { CachedOperation } from './cache';
+import { OperationWithCachePolicy } from './cache';
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 
 export interface OperationResult<TData = any> {
   data: TData | null;
@@ -12,8 +13,8 @@ export type CachePolicy = 'cache-and-network' | 'network-only' | 'cache-first' |
 
 export type QueryVariables = Record<string, any>;
 
-export interface Operation<TVars = QueryVariables> {
-  query: string | DocumentNode;
+export interface Operation<TData, TVars> {
+  query: string | DocumentNode | TypedDocumentNode<TData, TVars>;
   variables?: TVars;
 }
 
@@ -50,7 +51,7 @@ export type OperationType = 'query' | 'mutation' | 'subscription';
 
 export type AfterQueryCallback = (result: OperationResult) => void | Promise<void>;
 
-export type ClientPluginOperation = CachedOperation<unknown> & { type: OperationType; key: number };
+export type ClientPluginOperation = OperationWithCachePolicy<unknown, unknown> & { type: OperationType; key: number };
 
 export interface ClientPluginContext {
   useResult: (result: OperationResult<unknown>, terminate?: boolean) => void;

--- a/packages/villus/src/useMutation.ts
+++ b/packages/villus/src/useMutation.ts
@@ -3,11 +3,13 @@ import { Operation, QueryVariables } from './types';
 import { Client } from './client';
 import { CombinedError } from './utils';
 
-interface MutationCompositeOptions {
-  query: Operation['query'];
+interface MutationCompositeOptions<TData, TVars> {
+  query: Operation<TData, TVars>['query'];
 }
 
-export function useMutation<TData = any, TVars = QueryVariables>(opts: MutationCompositeOptions | Operation['query']) {
+export function useMutation<TData = any, TVars = QueryVariables>(
+  opts: MutationCompositeOptions<TData, TVars> | Operation<TData, TVars>['query']
+) {
   const client = inject('$villus') as Client;
   if (!client) {
     throw new Error('Cannot detect villus Client, did you forget to call `useClient`?');

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -3,8 +3,8 @@ import { CachePolicy, MaybeReactive, Operation, OperationResult, QueryVariables 
 import { Client } from './client';
 import { hash, CombinedError, toWatchableSource, stringify } from './utils';
 
-interface QueryCompositeOptions<TVars> {
-  query: MaybeReactive<Operation['query']>;
+interface QueryCompositeOptions<TData, TVars> {
+  query: MaybeReactive<Operation<TData, TVars>['query']>;
   variables?: MaybeReactive<TVars>;
   cachePolicy?: CachePolicy;
   fetchOnMount?: boolean;
@@ -33,7 +33,7 @@ function _useQuery<TData, TVars>({
   query,
   variables,
   cachePolicy,
-}: QueryCompositeOptions<TVars>): QueryComposable<TData> {
+}: QueryCompositeOptions<TData, TVars>): QueryComposable<TData> {
   const client = inject('$villus') as Client;
   if (!client) {
     throw new Error('Cannot detect villus Client, did you forget to call `useClient`?');
@@ -111,17 +111,16 @@ function _useQuery<TData, TVars>({
 }
 
 function useQuery<TData = any, TVars = QueryVariables>(
-  query: QueryCompositeOptions<TVars>['query'],
-  variables?: QueryCompositeOptions<TVars>['variables']
+  query: QueryCompositeOptions<TData, TVars>['query'],
+  variables?: QueryCompositeOptions<TData, TVars>['variables']
 ): ThenableQueryComposable<TData>;
 
 function useQuery<TData = any, TVars = QueryVariables>(
-  query: QueryCompositeOptions<TVars>
+  query: QueryCompositeOptions<TData, TVars>
 ): ThenableQueryComposable<TData>;
-
 function useQuery<TData = any, TVars = QueryVariables>(
-  opts: QueryCompositeOptions<TVars> | QueryCompositeOptions<TVars>['query'],
-  variables?: QueryCompositeOptions<TVars>['variables']
+  opts: QueryCompositeOptions<TData, TVars> | QueryCompositeOptions<TData, TVars>['query'],
+  variables?: QueryCompositeOptions<TData, TVars>['variables']
 ): ThenableQueryComposable<TData> {
   const normalizedOpts = normalizeOptions(opts, variables);
   const api = _useQuery<TData, TVars>(normalizedOpts);
@@ -142,10 +141,10 @@ function useQuery<TData = any, TVars = QueryVariables>(
   };
 }
 
-function normalizeOptions<TVars>(
-  opts: QueryCompositeOptions<TVars> | QueryCompositeOptions<TVars>['query'],
-  variables?: QueryCompositeOptions<TVars>['variables']
-): QueryCompositeOptions<TVars> {
+function normalizeOptions<TData, TVars>(
+  opts: QueryCompositeOptions<TData, TVars> | QueryCompositeOptions<TData, TVars>['query'],
+  variables?: QueryCompositeOptions<TData, TVars>['variables']
+): QueryCompositeOptions<TData, TVars> {
   const defaultOpts = {
     fetchOnMount: true,
   };

--- a/packages/villus/src/useSubscription.ts
+++ b/packages/villus/src/useSubscription.ts
@@ -3,8 +3,8 @@ import { Client } from './client';
 import { Unsub, Operation, OperationResult, QueryVariables } from './types';
 import { CombinedError } from './utils';
 
-interface SubscriptionCompositeOptions<TVars> {
-  query: Operation['query'];
+interface SubscriptionCompositeOptions<TData, TVars> {
+  query: Operation<TData, TVars>['query'];
   variables?: TVars;
 }
 
@@ -13,7 +13,7 @@ export type Reducer<TData = any, TResult = TData> = (prev: TResult | null, value
 export const defaultReducer: Reducer = (_, val) => val.data;
 
 export function useSubscription<TData = any, TResult = TData, TVars = QueryVariables>(
-  opts: SubscriptionCompositeOptions<TVars> | Operation['query'],
+  opts: SubscriptionCompositeOptions<TData, TVars> | Operation<TData, TVars>['query'],
   reduce: Reducer<TData, TResult> = defaultReducer
 ) {
   const client = inject('$villus') as Client;

--- a/packages/villus/src/utils/query.ts
+++ b/packages/villus/src/utils/query.ts
@@ -1,3 +1,4 @@
+import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DocumentNode, print } from 'graphql';
 import { Operation } from '../types';
 import { stringify } from './stringify';
@@ -5,7 +6,7 @@ import { stringify } from './stringify';
 /**
  * Normalizes a query string or object to a string.
  */
-export function normalizeQuery(query: string | DocumentNode): string | null {
+export function normalizeQuery(query: string | DocumentNode | TypedDocumentNode): string | null {
   if (typeof query === 'string') {
     return query;
   }
@@ -26,7 +27,7 @@ export function hash(x: string) {
   return h >>> 0;
 }
 
-export function getQueryKey(operation: Operation<unknown>) {
+export function getQueryKey(operation: Operation<unknown, unknown>) {
   const variables = operation.variables ? stringify(operation.variables) : '';
   const query = normalizeQuery(operation.query);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,7 +1253,7 @@
     is-promise "4.0.0"
     tslib "~2.0.1"
 
-"@graphql-typed-document-node/core@^3.0.0":
+"@graphql-typed-document-node/core@^3.0.0", "@graphql-typed-document-node/core@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
   integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==


### PR DESCRIPTION
This PR adds support for [TypedDocumentNode](https://github.com/dotansimha/graphql-typed-document-node#how-can-i-support-this-in-my-library) for imporved DX with the [graphql code generator project](https://graphql-code-generator.com/)

The type support is added to the composition API functions and to the client API

closes #61
