### PR TITLE
feat: dedup plugin

### DIFF
--- a/docs/content/guide/plugins.md
+++ b/docs/content/guide/plugins.md
@@ -12,6 +12,7 @@ Something you might not be aware of is that villus is pre-configured with a coup
 
 - [`fetch`](/plugins/fetch): used to execute queries on the network (actual fetching)
 - [`cache`](/plugins/cache): an in-memory simple cache that comes with villus by default, supports all cache policies
+- [`dedup`](/plugins/dedup): removes any duplicate pending queries
 
 Furthermore, villus exposes the default plugins as `defaultPlugins` function. To add plugins to villus client you need to pass a `use` array containing the plugins you would like to have
 

--- a/docs/content/plugins/batch.md
+++ b/docs/content/plugins/batch.md
@@ -1,7 +1,7 @@
 ---
 title: Query Batching Plugin
 description: Learn how to run batch multiple GraphQL queries
-order: 3
+order: 4
 ---
 
 # Query Batching

--- a/docs/content/plugins/cache.md
+++ b/docs/content/plugins/cache.md
@@ -6,11 +6,9 @@ order: 2
 
 # Cache Plugin
 
-The cache plugin is one of the default plugins that are pre-configured with any villus client unless specified otherwise, the cache plugin is a simple in-memory cache that clears whenever the page reloads or when the client is destroyed.
+The cache plugin is a simple in-memory cache that clears whenever the page reloads or when the client is destroyed. The cache plugin only applies it's caching logic to queries, as mutations require a fresh response from the server.
 
-The cache plugin only applies it's caching logic to queries, as mutations require a fresh response from the server.
-
-The cache plugin all the cache policies in villus:
+The cache plugin handles all the cache policies in villus:
 
 - `cache-first`: If found in cache return it, otherwise fetch it from the network
 - `network-only`: Always fetch from the network and do not cache it
@@ -24,6 +22,12 @@ useClient({
   use: [cache(), fetch()],
 });
 ```
+
+<doc-tip>
+
+The cache plugin is one of the default plugins that are pre-configured with any villus client unless specified otherwise
+
+</doc-tip>
 
 ## Options
 

--- a/docs/content/plugins/dedup.md
+++ b/docs/content/plugins/dedup.md
@@ -1,0 +1,33 @@
+---
+title: Dedup Plugin
+description: How the default dedup plugin works in villus
+order: 3
+---
+
+# Dedup Plugin
+
+The dedup plugin removes any duplicate pending queries from executing which means you can safely run the same queries at the same time without worrying about excessive requests.
+
+The dedup plugin only applies it's caching logic to queries. Mutations and subscriptions are excluded from the deduplication process.
+
+```js
+import { useClient, dedup, fetch } from 'villus';
+
+useClient({
+  use: [dedup(), fetch()],
+});
+```
+
+<doc-tip>
+
+The dedup plugin is one of the default plugins that are pre-configured with any villus client unless specified otherwise
+
+</doc-tip>
+
+## Options
+
+At this moment the dedup plugin doesn't have any options to customize
+
+## Code
+
+You can check the [source code for the `dedup` plugin](https://github.com/logaretm/villus/blob/main/packages/villus/src/dedup.ts) and use it as a reference to build your own

--- a/docs/content/plugins/fetch.md
+++ b/docs/content/plugins/fetch.md
@@ -1,12 +1,20 @@
 ---
 title: Fetch Plugin
-description: The default plugin that executes your queries
+description: The plugin that executes your queries
 order: 1
 ---
 
 # Fetch Plugin
 
-The fetch plugin is both a very simple plugin and a critical one to villus inner workings. Because villus is built using a pipeline of plugins that perform some processing on a GraphQL operation. The `fetch` plugin is treated as the one that actually executes your queries and mutations against the GraphQL API that is why it is very important to either have a `fetch` or `batch` plugins or any similar plugins you may write on your own.
+The fetch plugin is both a very simple plugin and a critical one to villus inner workings. Because villus is built using a pipeline of plugins that perform some processing on a GraphQL operation.
+
+The fetch plugin is the one that actually executes your queries and mutations against the GraphQL API which is why it is very important to either have a `fetch` or `batch` plugins or any similar plugins you may write on your own.
+
+<doc-tip>
+
+The fetch plugin is one of the default plugins that are pre-configured with any villus client unless specified otherwise
+
+</doc-tip>
 
 ## Options
 

--- a/docs/content/plugins/handle-subscriptions.md
+++ b/docs/content/plugins/handle-subscriptions.md
@@ -1,7 +1,7 @@
 ---
 title: Handle Subscriptions Plugin
 description: The plugin that executes your subscriptions
-order: 5
+order: 6
 ---
 
 # Handle Subscriptions Plugin

--- a/docs/content/plugins/multipart.md
+++ b/docs/content/plugins/multipart.md
@@ -1,7 +1,7 @@
 ---
 title: File Uploads
 description: Using the multipart plugin for file uploads
-order: 4
+order: 5
 ---
 
 # File Uploads

--- a/packages/villus/src/client.ts
+++ b/packages/villus/src/client.ts
@@ -1,5 +1,7 @@
-import { cache, OperationWithCachePolicy } from './cache';
 import { DEFAULT_FETCH_OPTS, getQueryKey } from './utils';
+import { cache, OperationWithCachePolicy } from './cache';
+import { fetch } from './fetch';
+import { dedup } from './dedup';
 import {
   OperationResult,
   CachePolicy,
@@ -12,7 +14,6 @@ import {
   AfterQueryCallback,
   ObservableLike,
 } from './types';
-import { fetch } from './fetch';
 
 export interface ClientOptions {
   url: string;
@@ -20,7 +21,7 @@ export interface ClientOptions {
   use?: ClientPlugin[];
 }
 
-export const defaultPlugins = () => [cache(), fetch()];
+export const defaultPlugins = () => [cache(), dedup(), fetch()];
 
 export class Client {
   private url: string;

--- a/packages/villus/src/dedup.ts
+++ b/packages/villus/src/dedup.ts
@@ -1,5 +1,4 @@
-import { ClientPlugin } from 'villus';
-import { OperationResult } from './types';
+import { ClientPlugin, OperationResult } from './types';
 
 export function dedup(): ClientPlugin {
   // Holds references to pending operations

--- a/packages/villus/src/dedup.ts
+++ b/packages/villus/src/dedup.ts
@@ -6,6 +6,11 @@ export function dedup(): ClientPlugin {
   const pendingLookup: Record<number, Promise<OperationResult>> = {};
 
   return function dedupPlugin(ctx) {
+    // Don't dedup mutations or subscriptions
+    if (ctx.operation.type !== 'query') {
+      return;
+    }
+
     // extract the original useResult function
     const { useResult } = ctx;
 

--- a/packages/villus/src/dedup.ts
+++ b/packages/villus/src/dedup.ts
@@ -35,7 +35,7 @@ export function dedup(): ClientPlugin {
     });
 
     // resolve the promise once the result are set via another plugin
-    ctx.useResult = function (...args) {
+    ctx.useResult = function (...args: [any, any]) {
       useResult(...args);
       resolveOp(args[0]);
     };

--- a/packages/villus/src/index.ts
+++ b/packages/villus/src/index.ts
@@ -10,4 +10,5 @@ export { useSubscription } from './useSubscription';
 export { handleSubscriptions, SubscriptionForwarder } from './handleSubscriptions';
 export { fetch } from './fetch';
 export { cache } from './cache';
+export { dedup } from './dedup';
 export { ClientPlugin, ClientPluginContext, FetchOptions } from './types';

--- a/packages/villus/test/useQuery.spec.ts
+++ b/packages/villus/test/useQuery.spec.ts
@@ -700,4 +700,26 @@ describe('useQuery()', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(document.querySelector('ul')?.children).toHaveLength(5);
   });
+
+  test('dedups duplicate queries', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
+
+        useQuery({ query: '{ posts { id title } }' });
+        useQuery({ query: '{ posts { id title } }' });
+        useQuery({ query: '{ posts { id title } }' });
+        useQuery({ query: '{ posts { id title slug } }' });
+        useQuery({ query: '{ posts { id title slug } }' });
+
+        return {};
+      },
+      template: `<div></div>`,
+    });
+
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledTimes(2); // only 2 unique queries were executed
+  });
 });


### PR DESCRIPTION
This PR adds a new default plugin called `dedup` and it **"removes"** duplicate queries and re-routes the results into the currently pending one.

That means you can safely run multiple duplicate queries across your apps and not worry about excessive requets.