### PR TITLE
feat: context response

### DIFF
--- a/packages/villus/src/client.ts
+++ b/packages/villus/src/client.ts
@@ -99,9 +99,10 @@ export class Client {
           }
         }
 
+        const afterQueryCtx = { response: context.response };
         for (let i = 0; i < afterQuery.length; i++) {
           const afterCb = afterQuery[i];
-          await afterCb(result as OperationResult<TData>);
+          await afterCb(result as OperationResult<TData>, afterQueryCtx);
         }
       })();
     });

--- a/packages/villus/src/fetch.ts
+++ b/packages/villus/src/fetch.ts
@@ -12,7 +12,8 @@ export function fetch(opts?: FetchPluginOpts): ClientPlugin {
     throw new Error('Could not resolve a fetch() method, you should provide one.');
   }
 
-  return async function fetchPlugin({ useResult, opContext, operation }) {
+  return async function fetchPlugin(ctx) {
+    const { useResult, opContext, operation } = ctx;
     const fetchOpts = makeFetchOptions(operation, opContext);
 
     let response;
@@ -28,6 +29,8 @@ export function fetch(opts?: FetchPluginOpts): ClientPlugin {
       );
     }
 
+    // Set the response on the context
+    ctx.response = response;
     if (!response.ok || !response.body) {
       // It is possible than a non-200 response is returned with errors, it should be treated as GraphQL error
       const ctorOptions: { response: typeof response; graphqlErrors?: GraphQLError[]; networkError?: Error } = {

--- a/packages/villus/src/types.ts
+++ b/packages/villus/src/types.ts
@@ -47,9 +47,20 @@ export interface FetchOptions extends RequestInit {
   headers: NonNullable<RequestInit['headers']>;
 }
 
+export interface ParsedResponse<TData> {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Headers;
+  body: GraphQLResponse<TData> | null;
+}
+
 export type OperationType = 'query' | 'mutation' | 'subscription';
 
-export type AfterQueryCallback = (result: OperationResult) => void | Promise<void>;
+export type AfterQueryCallback = (
+  result: OperationResult,
+  ctx: { response?: ParsedResponse<unknown> }
+) => void | Promise<void>;
 
 export type ClientPluginOperation = OperationWithCachePolicy<unknown, unknown> & { type: OperationType; key: number };
 
@@ -58,6 +69,7 @@ export interface ClientPluginContext {
   afterQuery: (cb: AfterQueryCallback) => void;
   operation: ClientPluginOperation;
   opContext: FetchOptions;
+  response?: ParsedResponse<unknown>;
 }
 
 export type ClientPlugin = ({ useResult, operation }: ClientPluginContext) => void | Promise<void>;

--- a/packages/villus/src/utils/network.ts
+++ b/packages/villus/src/utils/network.ts
@@ -1,12 +1,4 @@
-import { GraphQLResponse, FetchOptions, Fetcher } from '../types';
-
-interface ParsedResponse<TData> {
-  ok: boolean;
-  status: number;
-  statusText: string;
-  headers: Headers;
-  body: GraphQLResponse<TData> | null;
-}
+import { GraphQLResponse, FetchOptions, Fetcher, ParsedResponse } from '../types';
 
 export async function parseResponse<TData>(response: Response): Promise<ParsedResponse<TData>> {
   let json: GraphQLResponse<TData>;

--- a/packages/villus/test/client.spec.ts
+++ b/packages/villus/test/client.spec.ts
@@ -49,3 +49,20 @@ test('throws if no plugins set the result for the operation', async () => {
     'Operation result was not set by any plugin, make sure you have default plugins configured or review documentation'
   );
 });
+
+test('plugins can use the response', async () => {
+  const spy = jest.fn();
+  const plugin: ClientPlugin = async ({ afterQuery }) => {
+    afterQuery((_, { response }) => {
+      spy(response?.headers.get('content-type'));
+    });
+  };
+
+  const client = createClient({
+    url: 'https://test.com/graphql',
+    use: [plugin, ...defaultPlugins()],
+  });
+
+  await client.executeQuery({ query: '{ posts { id title } }' });
+  expect(spy).toHaveBeenCalledWith('application/json');
+});

--- a/packages/villus/test/server/setup.ts
+++ b/packages/villus/test/server/setup.ts
@@ -78,6 +78,10 @@ beforeEach(() => {
     simulateNetworkErrorWithGraphQLResponse: false,
   };
 
+  const headers = new Headers({
+    'content-type': 'application/json',
+  });
+
   (global as any).fetchController = fetchController;
 
   // setup a fetch mock
@@ -91,6 +95,7 @@ beforeEach(() => {
         ok: false,
         status: 400,
         statusText: 'Bad Request',
+        headers,
         json() {
           return {
             data: null,
@@ -119,6 +124,7 @@ beforeEach(() => {
       ok: true,
       status: 200,
       statusText: 'OK',
+      headers,
       json() {
         if (fetchController.simulateParseError) {
           throw new Error('Error parsing, unexpected token <');


### PR DESCRIPTION
Added the raw response property on the Plugin context and on the `afterQuery` callback

closes #62 