### PR TITLE
feat: initial isFetching

### DIFF
--- a/docs/content/api/query.md
+++ b/docs/content/api/query.md
@@ -18,14 +18,15 @@ The **Query** component is **renderless** by default, meaning it will not render
 
 The `Query` component accepts the following props:
 
-| Prop           | Type                                                                                         | Required | Description                                                                                           |
-| -------------- | -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| query          | `string` or `DocumentNode`                                                                   | **Yes**  | The query to be executed                                                                              |
-| variables      | `object`                                                                                     | **No**   | The query variables                                                                                   |
-| cachePolicy    | A `string` with those possible values `cache-and-network` or `network-only` or `cache-first` | **No**   | The cache policy to execute the query with, defaults to the value configured with the provided client |
-| fetchOnMount   | `boolean`                                                                                    | **No**   | If the query **should be** be executed on `onMounted` lifecycle hook, default is `true`               |
-| suspended      | `boolean`                                                                                    | **No**   | If the component is suspended with `Suspend` or not, defaults to `false`                              |
-| watchVariables | `boolean`                                                                                    | **No**   | If the query variable watching is disabled or not, defaults to `true`                                 |
+| Prop              | Type                                                                                         | Required | Description                                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| query             | `string` or `DocumentNode`                                                                   | **Yes**  | The query to be executed                                                                              |
+| variables         | `object`                                                                                     | **No**   | The query variables                                                                                   |
+| cachePolicy       | A `string` with those possible values `cache-and-network` or `network-only` or `cache-first` | **No**   | The cache policy to execute the query with, defaults to the value configured with the provided client |
+| fetchOnMount      | `boolean`                                                                                    | **No**   | If the query **should be** be executed on `onMounted` lifecycle hook, default is `true`               |
+| suspended         | `boolean`                                                                                    | **No**   | If the component is suspended with `Suspend` or not, defaults to `false`                              |
+| watchVariables    | `boolean`                                                                                    | **No**   | If the query variable watching is disabled or not, defaults to `true`                                 |
+| initialIsFetching | `boolean`                                                                                    | **No**   | Sets `isFetching` to an initial value                                                                 |
 
 ## Slot Props
 

--- a/docs/content/api/use-query.md
+++ b/docs/content/api/use-query.md
@@ -58,12 +58,13 @@ const { data, error } = useQuery({
 
 This is the full object fields that the `useQuery` function accepts:
 
-| Property     | Type                                                                                         | Required | Description                                                                                           |
-| ------------ | -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| query        | `string` or `DocumentNode` or `Ref<string>`                                                  | **Yes**  | The query to be executed                                                                              |
-| variables    | `object` or `Ref<object>`                                                                    | **No**   | The query variables                                                                                   |
-| cachePolicy  | A `string` with those possible values `cache-and-network` or `network-only` or `cache-first` | **No**   | The cache policy to execute the query with, defaults to the value configured with the provided client |
-| fetchOnMount | `boolean`                                                                                    | **No**   | If the query **should be** executed on `mounted`, default is `true`                                   |
+| Property          | Type                                                                                         | Required | Description                                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| query             | `string` or `DocumentNode` or `Ref<string>`                                                  | **Yes**  | The query to be executed                                                                              |
+| variables         | `object` or `Ref<object>`                                                                    | **No**   | The query variables                                                                                   |
+| cachePolicy       | A `string` with those possible values `cache-and-network` or `network-only` or `cache-first` | **No**   | The cache policy to execute the query with, defaults to the value configured with the provided client |
+| fetchOnMount      | `boolean`                                                                                    | **No**   | If the query **should be** executed on `mounted`, default is `true`                                   |
+| initialIsFetching | `boolean`                                                                                    | **No**   | Setting an initial `isFetching` value, default is `false`                                             |
 
 This signature allows you to tweak the `fetchOnMount` and `cachePolicy` behaviors for the query, Here is an example:
 

--- a/docs/content/guide/queries.md
+++ b/docs/content/guide/queries.md
@@ -446,3 +446,69 @@ export default {
 };
 <script>
 ```
+
+## Fetching Indication
+
+It is very common to display an indication for pending queries in your UI so your users know that something is being done, the `useQuery` composition function exposes a `isFetching` boolean ref that you can use to display such indicators.
+
+```vue
+<template>
+  <div>
+    <ul v-if="data">
+      <li v-for="post in data.posts" :key="post.id">{{ post.title }}</li>
+    </ul>
+
+    <p v-if="isFetching">Loading...</p>
+  </div>
+</template>
+
+<script>
+import { useQuery } from 'villus';
+
+export default {
+  setup() {
+    const GetPosts = `
+      query GetPosts {
+        posts {
+          id
+          title
+        }
+      }
+    `;
+
+    const { data, isFetching } = useQuery({
+      query: GetPosts,
+    });
+
+    return { data, isFetching };
+  },
+};
+</script>
+```
+
+Whenever a re-fetch is triggered, or the query was executed again the `isFetching` will be updated accordingly so you don't have to keep it in sync with anything nor you have to create your own boolean refs for indications.
+
+<doc-tip title="Initial isFetching">
+
+Because `isFetching` is initially set to `false`, you might see a flash of your content due to the default fetching behavior when the component mounts, so there is a short time before it is set to `true`.
+
+To avoid this you could set the `isFetching` value either by setting it directly:
+
+```js
+const { data, isFetching } = useQuery({
+  query: GetPosts,
+});
+
+isFetching.value = true;
+```
+
+Or you could set it in the query options:
+
+```js
+const { data, isFetching } = useQuery({
+  query: GetPosts,
+  initialIsFetching: true,
+});
+```
+
+</doc-tip>

--- a/packages/villus/src/Query.ts
+++ b/packages/villus/src/Query.ts
@@ -30,6 +30,10 @@ export const Query = defineComponent({
       type: Boolean,
       default: true,
     },
+    initialIsFetching: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props, ctx) {
     function createRenderFn(api: ReturnType<typeof useQuery>) {
@@ -70,6 +74,7 @@ export const Query = defineComponent({
       variables: toRef(props, 'variables') as Ref<Record<string, any> | undefined>,
       fetchOnMount: props.fetchOnMount,
       cachePolicy: props.cachePolicy as CachePolicy,
+      initialIsFetching: props.initialIsFetching,
     };
 
     if (props.suspended) {

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -8,6 +8,7 @@ interface QueryCompositeOptions<TData, TVars> {
   variables?: MaybeReactive<TVars>;
   cachePolicy?: CachePolicy;
   fetchOnMount?: boolean;
+  initialIsFetching?: boolean;
 }
 
 interface QueryExecutionOpts {
@@ -19,9 +20,9 @@ function useQuery<TData = any, TVars = QueryVariables>(opts: QueryCompositeOptio
     return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
   });
 
-  let { query, variables, cachePolicy, fetchOnMount } = normalizeOptions(opts);
+  let { query, variables, cachePolicy, fetchOnMount, initialIsFetching } = normalizeOptions(opts);
   const data: Ref<TData | null> = ref(null);
-  const isFetching = ref(false);
+  const isFetching = ref(initialIsFetching);
   const isDone = ref(false);
   const error: Ref<CombinedError | null> = ref(null);
 
@@ -113,6 +114,7 @@ function normalizeOptions<TData, TVars>(
   const defaultOpts = {
     variables: {} as TVars,
     fetchOnMount: true,
+    initialIsFetching: false,
   };
 
   return {

--- a/packages/villus/test/useQuery.spec.ts
+++ b/packages/villus/test/useQuery.spec.ts
@@ -722,4 +722,28 @@ describe('useQuery()', () => {
     await flushPromises();
     expect(fetch).toHaveBeenCalledTimes(2); // only 2 unique queries were executed
   });
+
+  test('can set initial isFetching value with initialIsFetching', async () => {
+    mount({
+      setup() {
+        useClient({
+          url: 'https://test.com/graphql',
+        });
+
+        const { isFetching } = useQuery({
+          query: '{ posts { id title } }',
+          fetchOnMount: false,
+          initialIsFetching: true,
+        });
+
+        return {
+          isFetching,
+        };
+      },
+      template: `<div id="el">{{ isFetching }}</div>`,
+    });
+
+    await flushPromises();
+    expect(document.querySelector('#el')?.textContent).toBe('true');
+  });
 });


### PR DESCRIPTION
This PR adds the ability to set `isFetching` to an initial value which helps with displaying indicators.

The default value is `false`, which might cause an unintended flash of rendered content while the component is being mounted. Having the option to set it initially to `true` avoids this issues.