### PR TITLE
Fix error in the docs for Plugins

### DIFF
--- a/docs/content/guide/plugins.md
+++ b/docs/content/guide/plugins.md
@@ -184,7 +184,7 @@ const myPlugin = definePlugin(({ opContext }) => {
   opContext.headers.Authorization = 'Bearer <token>';
 });
 
-const myPluginWithConfig = (config: { prefix: string }) => {
+const myPluginWithConfig = (prefix: string) => {
   // opContext will be automatically typed
   return definePlugin(({ opContext }) => {
     // Add auth headers with configurable prefix

--- a/docs/content/guide/plugins.md
+++ b/docs/content/guide/plugins.md
@@ -184,11 +184,11 @@ const myPlugin = definePlugin(({ opContext }) => {
   opContext.headers.Authorization = 'Bearer <token>';
 });
 
-const myPluginWithConfig = (prefix: string) => {
+const myPluginWithConfig = (config: { prefix: string }) => {
   // opContext will be automatically typed
   return definePlugin(({ opContext }) => {
     // Add auth headers with configurable prefix
-    opContext.headers.Authorization = `${prefix} <token>`;
+    opContext.headers.Authorization = `${config.prefix} <token>`;
   });
 };
 ```


### PR DESCRIPTION
Using config caused 'prefix' to not exist, can either remove the config part or use `config.prefix`.