### PR TITLE
feat: request cancellation

### DIFF
--- a/packages/villus/src/client.ts
+++ b/packages/villus/src/client.ts
@@ -50,7 +50,7 @@ export class Client {
   private async execute<TData, TVars>(
     operation: Operation<TData, TVars> | OperationWithCachePolicy<TData, TVars>,
     type: OperationType,
-    queryContext?: QueryExecutionContext,
+    queryContext?: Partial<QueryExecutionContext>,
     onResultChanged?: OnResultChangedCallback<TData>
   ): Promise<OperationResult<TData>> {
     let result: OperationResult<TData> | undefined;
@@ -58,6 +58,7 @@ export class Client {
       url: this.url,
       ...DEFAULT_FETCH_OPTS,
       headers: { ...DEFAULT_FETCH_OPTS.headers, ...(queryContext?.headers || {}) },
+      signal: queryContext?.signal,
     };
 
     let terminateSignal = false;
@@ -130,7 +131,7 @@ export class Client {
 
   public async executeQuery<TData = any, TVars = QueryVariables>(
     operation: OperationWithCachePolicy<TData, TVars>,
-    queryContext?: QueryExecutionContext,
+    queryContext?: Partial<QueryExecutionContext>,
     onResultChanged?: OnResultChangedCallback<TData>
   ): Promise<OperationResult<TData>> {
     return this.execute<TData, TVars>(operation, 'query', queryContext, onResultChanged);
@@ -138,7 +139,7 @@ export class Client {
 
   public async executeMutation<TData = any, TVars = QueryVariables>(
     operation: Operation<TData, TVars>,
-    queryContext?: QueryExecutionContext
+    queryContext?: Partial<QueryExecutionContext>
   ): Promise<OperationResult<TData>> {
     return this.execute<TData, TVars>(operation, 'mutation', queryContext);
   }

--- a/packages/villus/src/fetch.ts
+++ b/packages/villus/src/fetch.ts
@@ -1,7 +1,7 @@
 import { GraphQLError } from 'graphql';
 import { ClientPlugin } from './types';
 import { makeFetchOptions, resolveGlobalFetch, parseResponse } from '../../shared/src';
-import { CombinedError } from './utils';
+import { CombinedError, isAbortError } from './utils';
 
 interface FetchPluginOpts {
   fetch?: typeof window['fetch'];
@@ -21,6 +21,17 @@ export function fetch(opts?: FetchPluginOpts): ClientPlugin {
     try {
       response = await fetch(opContext.url as string, fetchOpts).then(parseResponse);
     } catch (err) {
+      if (isAbortError(err)) {
+        return useResult(
+          {
+            data: null,
+            error: null,
+            aborted: true,
+          },
+          true
+        );
+      }
+
       return useResult(
         {
           data: null,

--- a/packages/villus/src/types.ts
+++ b/packages/villus/src/types.ts
@@ -6,6 +6,7 @@ import { ParsedResponse, FetchOptions, Operation } from '../../shared/src';
 export interface OperationResult<TData = any> {
   data: TData | null;
   error: CombinedError | null;
+  aborted?: boolean;
 }
 
 export type CachePolicy = 'cache-and-network' | 'network-only' | 'cache-first' | 'cache-only';
@@ -49,6 +50,7 @@ export type ClientPluginOperation = OperationWithCachePolicy<unknown, QueryVaria
 
 export interface QueryExecutionContext {
   headers: Record<string, string>;
+  signal: AbortSignal;
 }
 
 export interface ClientPluginContext {

--- a/packages/villus/src/useMutation.ts
+++ b/packages/villus/src/useMutation.ts
@@ -5,7 +5,7 @@ import { VILLUS_CLIENT } from './symbols';
 import { Operation } from '../../shared/src';
 
 interface MutationExecutionOptions {
-  context: MaybeRef<QueryExecutionContext>;
+  context: MaybeRef<Partial<QueryExecutionContext>>;
 }
 
 export function useMutation<TData = any, TVars = QueryVariables>(

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -62,13 +62,13 @@ function useQuery<TData = any, TVars = QueryVariables>(
   }
 
   async function execute(overrideOpts?: Partial<QueryExecutionOpts<TVars>>) {
-    isFetching.value = true;
-    const vars = (isRef(variables) ? variables.value : variables) || {};
     if (lastPendingOperation) {
       abort();
     }
 
+    isFetching.value = true;
     abortController.value = createAbortController();
+    const vars = (isRef(variables) ? variables.value : variables) || {};
     const pendingExecution = client.executeQuery<TData, TVars>(
       {
         query: isRef(query) ? query.value : query,
@@ -90,8 +90,12 @@ function useQuery<TData = any, TVars = QueryVariables>(
       return { data: res.data as TData, error: res.error };
     }
 
+    lastPendingOperation = undefined;
+    abortController.value = undefined;
+
     if (res.aborted) {
       isFetching.value = false;
+
       return res;
     }
 
@@ -100,8 +104,6 @@ function useQuery<TData = any, TVars = QueryVariables>(
     error.value = res.error;
     isDone.value = true;
     isFetching.value = false;
-    lastPendingOperation = undefined;
-    abortController.value = undefined;
 
     return { data: data.value, error: error.value };
   }

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -8,7 +8,7 @@ import { Operation } from '../../shared/src';
 interface QueryCompositeOptions<TData, TVars> {
   query: MaybeRef<Operation<TData, TVars>['query']>;
   variables?: MaybeRef<TVars>;
-  context?: MaybeRef<QueryExecutionContext>;
+  context?: MaybeRef<Partial<QueryExecutionContext>>;
   cachePolicy?: CachePolicy;
   fetchOnMount?: boolean;
 }

--- a/packages/villus/src/utils/common.ts
+++ b/packages/villus/src/utils/common.ts
@@ -26,3 +26,18 @@ export function injectWithSelf<T>(symbol: InjectionKey<T>, onMissing: () => Erro
 
   return injection;
 }
+
+/**
+ * Creates an abort controller while being aware of the execution environment
+ */
+export function createAbortController(): AbortController | undefined {
+  if (typeof window !== 'undefined' && 'AbortController' in window && window.AbortController) {
+    return new window.AbortController();
+  }
+
+  if (typeof global !== 'undefined' && 'AbortController' in global && global.AbortController) {
+    return new global.AbortController();
+  }
+
+  return undefined;
+}

--- a/packages/villus/src/utils/error.ts
+++ b/packages/villus/src/utils/error.ts
@@ -71,3 +71,7 @@ export class CombinedError extends Error {
     return this.message;
   }
 }
+
+export function isAbortError(err: Error) {
+  return err.name === 'AbortError';
+}


### PR DESCRIPTION
This PR brings `AbortController` support to cancel ongoing requests.

Aside from that, if the same query/mutation triggered multiple requests, it will be canceled by default.

The only problem is to workout the interaction between cancellation and `dedup` and `batch` plugins.

For `dedup` it is problematic to cancel a deduped request because that means it would cancel for other queries as well. There isn't a lot of options here other than "avoid" deduped requests abort signal to prevent mistakes.

For `batch`, that would cancel the whole batched request. I don't think I have much choice here other than not supporting cancellation with `batch`.


closes #90 