### PR TITLE
fix: normalize the multipart queries closes #112

### DIFF
--- a/packages/multipart/src/index.ts
+++ b/packages/multipart/src/index.ts
@@ -1,5 +1,6 @@
 import { definePlugin } from 'villus';
 import { extractFiles } from 'extract-files';
+import { normalizeQuery } from '../../shared/src';
 
 export function multipart() {
   return definePlugin(function multipartPlugin(context) {
@@ -16,7 +17,7 @@ export function multipart() {
     }
 
     const body = new FormData();
-    body.append('operations', JSON.stringify({ query: operation.query, variables }));
+    body.append('operations', JSON.stringify({ query: normalizeQuery(operation.query), variables }));
 
     const map: Record<number, string[]> = {};
     let i = 0;


### PR DESCRIPTION
## What

The `@villus/multipart` package does not normalize the `operation.query` sent via the network, which makes using `graphql-tag` or `TypedDocuments` not work properly with APIs that do not support AST documents (most non-apollo) servers.

## How

This PR uses the `normalizeQuery` helper function already used in other plugins to "print" the query to string before sending it.

closes #112