### PR TITLE
fix: add export types for villus.d.ts

### DIFF
--- a/packages/villus/src/index.ts
+++ b/packages/villus/src/index.ts
@@ -1,12 +1,12 @@
-export { createClient, defaultPlugins, Client } from './client';
+export { createClient, ClientOptions, defaultPlugins, Client } from './client';
 export { Provider, withProvider } from './Provider';
 export { Query } from './Query';
 export { Mutation } from './Mutation';
 export { Subscription } from './Subscription';
 export { useClient } from './useClient';
-export { useQuery } from './useQuery';
+export { useQuery, QueryApi, BaseQueryApi } from './useQuery';
 export { useMutation } from './useMutation';
-export { useSubscription } from './useSubscription';
+export { useSubscription, Reducer } from './useSubscription';
 export { handleSubscriptions, SubscriptionForwarder } from './handleSubscriptions';
 export { fetch } from './fetch';
 export { cache } from './cache';


### PR DESCRIPTION
The interfaces like QueryApi has exported in useQuery.ts, but it doesn't export in villus.d.ts. because of they don't  put in index.ts (the entry file of rollup-plugin-dts). The author has explain in this issue: https://github.com/Swatinem/rollup-plugin-dts/issues/178#issuecomment-1079488734  

In some cases, QueryApi (.etc) should be export for typescript to infer type, so I add the types that exported in .ts file but not in file index.ts.

one case I come across:
```ts
import type { customizeUseQueryOpts } from './villusExtendTypes'
import { useQuery } from 'villus'
import { TaskByIdDocument, TaskByIdQueryVariables } from '@/service/queries'

export function useTaskById(
  opts: customizeUseQueryOpts<TaskByIdQueryVariables>,
) {
  const res = useQuery({
    query: TaskByIdDocument,
    ...opts,
  })
  return res
}
// ts warn: Return type of exported function has or is using name 'QueryApi' from external module
// when QueryApi type exported, it will has infer return type with no warn.
```

I hope it can help.