### PR TITLE
feat: enable useQuery etc function outside of setup and outside component

### DIFF
--- a/packages/villus/src/client.ts
+++ b/packages/villus/src/client.ts
@@ -41,8 +41,14 @@ export const setActiveClient = (client: Client | undefined) => (activeClient = c
 /**
  * Get the currently active client if there is any.
  */
-// If want get currentInstance client and response is not expected, notice resolveClient in common.ts may be exec first.
-export const getActiveClient = () => activeClient;
+export const getActiveClient = () => {
+  const vm = getCurrentInstance();
+  if (!vm) {
+    return activeClient;
+  }
+
+  return vm.provides?.[VILLUS_CLIENT] ||  inject(VILLUS_CLIENT, activeClient);
+}
 
 type OnResultChangedCallback<TData> = (result: OperationResult<TData>) => unknown;
 

--- a/packages/villus/src/client.ts
+++ b/packages/villus/src/client.ts
@@ -42,7 +42,7 @@ export const setActiveClient = (client: Client | undefined) => (activeClient = c
  * Get the currently active client if there is any.
  */
 export const getActiveClient = () => {
-  const vm = getCurrentInstance();
+  const vm = getCurrentInstance() as any;
   if (!vm) {
     return activeClient;
   }

--- a/packages/villus/src/client.ts
+++ b/packages/villus/src/client.ts
@@ -47,7 +47,7 @@ export const getActiveClient = () => {
     return activeClient;
   }
 
-  return vm.provides?.[VILLUS_CLIENT] ||  inject(VILLUS_CLIENT, activeClient);
+  return vm.provides?.[VILLUS_CLIENT as any] || inject(VILLUS_CLIENT, activeClient);
 }
 
 type OnResultChangedCallback<TData> = (result: OperationResult<TData>) => unknown;

--- a/packages/villus/src/client.ts
+++ b/packages/villus/src/client.ts
@@ -29,7 +29,7 @@ export interface ClientOptions {
  * setActiveClient should be called to solve problem outside setup
  */
 // eslint-disable-next-line no-use-before-define
-export let activeClient: Client | undefined;
+let activeClient: Client | undefined;
 
 /**
  * Sets or unsets the active client
@@ -41,7 +41,7 @@ export const setActiveClient = (client: Client | undefined) => (activeClient = c
 /**
  * Get the currently active client if there is any.
  */
-export const getActiveClient = () => (getCurrentInstance() && inject(VILLUS_CLIENT)) || activeClient;
+export const getActiveClient = () => activeClient;
 
 type OnResultChangedCallback<TData> = (result: OperationResult<TData>) => unknown;
 

--- a/packages/villus/src/client.ts
+++ b/packages/villus/src/client.ts
@@ -41,6 +41,7 @@ export const setActiveClient = (client: Client | undefined) => (activeClient = c
 /**
  * Get the currently active client if there is any.
  */
+// If want get currentInstance client and response is not expected, notice resolveClient in common.ts may be exec first.
 export const getActiveClient = () => activeClient;
 
 type OnResultChangedCallback<TData> = (result: OperationResult<TData>) => unknown;

--- a/packages/villus/src/index.ts
+++ b/packages/villus/src/index.ts
@@ -1,12 +1,12 @@
-export { createClient, defaultPlugins, Client } from './client';
+export { createClient, ClientOptions, defaultPlugins, Client } from './client';
 export { Provider, withProvider } from './Provider';
 export { Query } from './Query';
 export { Mutation } from './Mutation';
 export { Subscription } from './Subscription';
 export { useClient } from './useClient';
-export { useQuery } from './useQuery';
+export { useQuery, QueryApi, BaseQueryApi } from './useQuery';
 export { useMutation } from './useMutation';
-export { useSubscription } from './useSubscription';
+export { useSubscription, Reducer } from './useSubscription';
 export { handleSubscriptions, SubscriptionForwarder } from './handleSubscriptions';
 export { fetch } from './fetch';
 export { cache } from './cache';

--- a/packages/villus/src/index.ts
+++ b/packages/villus/src/index.ts
@@ -1,10 +1,10 @@
-export { createClient, ClientOptions, defaultPlugins, Client } from './client';
+export { createClient, defaultPlugins, setActiveClient, getActiveClient, ClientOptions, Client } from './client';
 export { Provider, withProvider } from './Provider';
 export { Query } from './Query';
 export { Mutation } from './Mutation';
 export { Subscription } from './Subscription';
 export { useClient } from './useClient';
-export { useQuery, QueryApi, BaseQueryApi } from './useQuery';
+export { useQuery, QueryApi, BaseQueryApi, QueryCompositeOptions } from './useQuery';
 export { useMutation } from './useMutation';
 export { useSubscription, Reducer } from './useSubscription';
 export { handleSubscriptions, SubscriptionForwarder } from './handleSubscriptions';

--- a/packages/villus/src/useMutation.ts
+++ b/packages/villus/src/useMutation.ts
@@ -3,6 +3,7 @@ import { MaybeRef, OperationResult, QueryExecutionContext, QueryVariables } from
 import { CombinedError, injectWithSelf } from './utils';
 import { VILLUS_CLIENT } from './symbols';
 import { Operation } from '../../shared/src';
+import { Client } from './client';
 
 interface MutationExecutionOptions {
   context: MaybeRef<QueryExecutionContext>;
@@ -10,11 +11,14 @@ interface MutationExecutionOptions {
 
 export function useMutation<TData = any, TVars = QueryVariables>(
   query: Operation<TData, TVars>['query'],
-  opts?: Partial<MutationExecutionOptions>
+  opts?: Partial<MutationExecutionOptions>,
+  manualClient?: Client
 ) {
-  const client = injectWithSelf(VILLUS_CLIENT, () => {
-    return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
-  });
+  const client =
+    manualClient ??
+    injectWithSelf(VILLUS_CLIENT, () => {
+      return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
+    });
 
   const data: Ref<TData | null> = ref(null);
   const isFetching = ref(false);

--- a/packages/villus/src/useMutation.ts
+++ b/packages/villus/src/useMutation.ts
@@ -1,6 +1,6 @@
 import { ref, Ref, unref } from 'vue';
 import { MaybeRef, OperationResult, QueryExecutionContext, QueryVariables } from './types';
-import { CombinedError, injectWithSelf } from './utils';
+import { CombinedError, resolveClient } from './utils';
 import { VILLUS_CLIENT } from './symbols';
 import { Operation } from '../../shared/src';
 import { Client } from './client';
@@ -14,11 +14,7 @@ export function useMutation<TData = any, TVars = QueryVariables>(
   opts?: Partial<MutationExecutionOptions>,
   manualClient?: Client
 ) {
-  const client =
-    manualClient ??
-    injectWithSelf(VILLUS_CLIENT, () => {
-      return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
-    });
+  const client = manualClient ?? resolveClient(VILLUS_CLIENT);
 
   const data: Ref<TData | null> = ref(null);
   const isFetching = ref(false);

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -1,7 +1,7 @@
 import { isReactive, isRef, onMounted, Ref, ref, unref, watch, getCurrentInstance } from 'vue';
 import stringify from 'fast-json-stable-stringify';
 import { CachePolicy, MaybeRef, OperationResult, QueryExecutionContext, QueryVariables } from './types';
-import { hash, CombinedError, toWatchableSource, injectWithSelf } from './utils';
+import { hash, CombinedError, toWatchableSource, resolveClient } from './utils';
 import { VILLUS_CLIENT } from './symbols';
 import { Operation } from '../../shared/src';
 import { Client } from './client';
@@ -40,11 +40,7 @@ function useQuery<TData = any, TVars = QueryVariables>(
   opts: QueryCompositeOptions<TData, TVars>,
   manualClient?: Client
 ): QueryApi<TData, TVars> {
-  const client =
-    manualClient ??
-    injectWithSelf(VILLUS_CLIENT, () => {
-      return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
-    });
+  const client = manualClient ?? resolveClient(VILLUS_CLIENT);
 
   let { query, variables, cachePolicy, fetchOnMount } = normalizeOptions(opts);
   const data: Ref<TData | null> = ref(null);

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -1,11 +1,12 @@
-import { isReactive, isRef, onMounted, Ref, ref, unref, watch } from 'vue';
+import { isReactive, isRef, onMounted, Ref, ref, unref, watch, getCurrentInstance } from 'vue';
 import stringify from 'fast-json-stable-stringify';
 import { CachePolicy, MaybeRef, OperationResult, QueryExecutionContext, QueryVariables } from './types';
 import { hash, CombinedError, toWatchableSource, injectWithSelf } from './utils';
 import { VILLUS_CLIENT } from './symbols';
 import { Operation } from '../../shared/src';
+import { Client } from './client';
 
-interface QueryCompositeOptions<TData, TVars> {
+export interface QueryCompositeOptions<TData, TVars> {
   query: MaybeRef<Operation<TData, TVars>['query']>;
   variables?: MaybeRef<TVars>;
   context?: MaybeRef<QueryExecutionContext>;
@@ -36,11 +37,14 @@ export interface QueryApi<TData, TVars> extends BaseQueryApi<TData, TVars> {
 }
 
 function useQuery<TData = any, TVars = QueryVariables>(
-  opts: QueryCompositeOptions<TData, TVars>
+  opts: QueryCompositeOptions<TData, TVars>,
+  manualClient?: Client
 ): QueryApi<TData, TVars> {
-  const client = injectWithSelf(VILLUS_CLIENT, () => {
-    return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
-  });
+  const client =
+    manualClient ??
+    injectWithSelf(VILLUS_CLIENT, () => {
+      return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
+    });
 
   let { query, variables, cachePolicy, fetchOnMount } = normalizeOptions(opts);
   const data: Ref<TData | null> = ref(null);
@@ -133,11 +137,15 @@ function useQuery<TData = any, TVars = QueryVariables>(
 
   const api = { data, isFetching, isDone, error, execute, unwatchVariables, watchVariables, isWatchingVariables };
 
-  onMounted(() => {
-    if (fetchOnMount) {
-      execute();
-    }
-  });
+  /**
+   * if can not getCurrentInstance, the func use outside of setup, cannot get onMounted
+   * when outside of setup and fetchOnMount is true, execute immediately, but a little confused
+   * todo: maybe better to add a new param decide execute immediately, but it's ok also now
+   */
+  const vm = getCurrentInstance();
+  if (fetchOnMount) {
+    vm ? onMounted(() => execute()) : execute();
+  }
 
   return {
     ...api,

--- a/packages/villus/src/useSubscription.ts
+++ b/packages/villus/src/useSubscription.ts
@@ -1,7 +1,7 @@
 import { ref, Ref, onMounted, unref, onBeforeUnmount, watch, isRef, getCurrentInstance } from 'vue';
 import { VILLUS_CLIENT } from './symbols';
 import { Unsubscribable, OperationResult, QueryVariables, MaybeRef, StandardOperationResult } from './types';
-import { CombinedError, injectWithSelf } from './utils';
+import { CombinedError, resolveClient } from './utils';
 import { Operation } from '../../shared/src';
 import { Client } from './client';
 
@@ -20,11 +20,7 @@ export function useSubscription<TData = any, TResult = TData, TVars = QueryVaria
   reduce: Reducer<TData, TResult> = defaultReducer,
   manualClient?: Client
 ) {
-  const client =
-    manualClient ??
-    injectWithSelf(VILLUS_CLIENT, () => {
-      return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
-    });
+  const client = manualClient ?? resolveClient(VILLUS_CLIENT);
 
   const data = ref<TResult | null>(reduce(null, { data: null, error: null }));
   const error: Ref<CombinedError | null> = ref(null);

--- a/packages/villus/src/useSubscription.ts
+++ b/packages/villus/src/useSubscription.ts
@@ -1,8 +1,9 @@
-import { ref, Ref, onMounted, unref, onBeforeUnmount, watch, isRef } from 'vue';
+import { ref, Ref, onMounted, unref, onBeforeUnmount, watch, isRef, getCurrentInstance } from 'vue';
 import { VILLUS_CLIENT } from './symbols';
 import { Unsubscribable, OperationResult, QueryVariables, MaybeRef, StandardOperationResult } from './types';
 import { CombinedError, injectWithSelf } from './utils';
 import { Operation } from '../../shared/src';
+import { Client } from './client';
 
 interface SubscriptionCompositeOptions<TData, TVars> {
   query: MaybeRef<Operation<TData, TVars>['query']>;
@@ -16,11 +17,14 @@ export const defaultReducer: Reducer = (_, val) => val.data;
 
 export function useSubscription<TData = any, TResult = TData, TVars = QueryVariables>(
   { query, variables, paused }: SubscriptionCompositeOptions<TData, TVars>,
-  reduce: Reducer<TData, TResult> = defaultReducer
+  reduce: Reducer<TData, TResult> = defaultReducer,
+  manualClient?: Client
 ) {
-  const client = injectWithSelf(VILLUS_CLIENT, () => {
-    return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
-  });
+  const client =
+    manualClient ??
+    injectWithSelf(VILLUS_CLIENT, () => {
+      return new Error('Cannot detect villus Client, did you forget to call `useClient`?');
+    });
 
   const data = ref<TResult | null>(reduce(null, { data: null, error: null }));
   const error: Ref<CombinedError | null> = ref(null);
@@ -63,18 +67,21 @@ export function useSubscription<TData = any, TResult = TData, TVars = QueryVaria
     });
   }
 
+  /**
+   * if can not getCurrentInstance, the func use outside of setup, cannot get onMounted
+   * when outside of setup initObserver immediately.
+   */
   let observer: Unsubscribable;
+  const vm = getCurrentInstance();
   if (!paused) {
-    onMounted(async () => {
+    const getObserver = async () => {
       observer = await initObserver();
-    });
+    };
+    vm ? onMounted(() => getObserver()) : getObserver();
   }
 
-  onBeforeUnmount(() => {
-    if (observer) {
-      observer.unsubscribe();
-    }
-  });
+  // todo: if outside of setup, it should be recommend manually pause it(or someaction else)
+  vm && onBeforeUnmount(() => observer && observer.unsubscribe());
 
   function pause() {
     isPaused.value = true;

--- a/packages/villus/src/utils/common.ts
+++ b/packages/villus/src/utils/common.ts
@@ -1,4 +1,5 @@
 import { getCurrentInstance, inject, InjectionKey, isReactive, isRef, Ref, toRefs, WatchSource } from 'vue';
+import { activeClient, setActiveClient } from '../client';
 
 export function toWatchableSource<T = any>(value: Ref<T> | Record<string, any>): WatchSource | WatchSource[] {
   if (isRef(value)) {
@@ -16,13 +17,17 @@ export function toWatchableSource<T = any>(value: Ref<T> | Record<string, any>):
 
 // Uses same component provide as its own injections
 // Due to changes in https://github.com/vuejs/vue-next/pull/2424
+// todo: maybe better to modify func name and add manual client args here
 export function injectWithSelf<T>(symbol: InjectionKey<T>, onMissing: () => Error): T {
   const vm = getCurrentInstance() as any;
+  let client = vm && inject(symbol, vm?.provides?.[symbol as any]);
 
-  const injection = inject(symbol, vm?.provides?.[symbol as any]);
-  if (injection === null || injection === undefined) {
+  if (client) setActiveClient(client);
+  client = activeClient;
+
+  if (client === null || client === undefined) {
     throw onMissing();
   }
 
-  return injection;
+  return client;
 }

--- a/packages/villus/src/utils/common.ts
+++ b/packages/villus/src/utils/common.ts
@@ -1,5 +1,5 @@
 import { getCurrentInstance, inject, InjectionKey, isReactive, isRef, Ref, toRefs, WatchSource } from 'vue';
-import { activeClient, setActiveClient } from '../client';
+import { getActiveClient, setActiveClient } from '../client';
 
 export function toWatchableSource<T = any>(value: Ref<T> | Record<string, any>): WatchSource | WatchSource[] {
   if (isRef(value)) {

--- a/packages/villus/src/utils/common.ts
+++ b/packages/villus/src/utils/common.ts
@@ -23,7 +23,7 @@ export function resolveClient(): Client {
   let client = vm && inject(symbol, vm?.provides?.[symbol as any]);
 
   if (client) setActiveClient(client);
-  client = activeClient;
+  client = getActiveClient();
 
   if (client === null || client === undefined) {
     throw new Error('Cannot detect villus Client, did you forget to call `useClient`?');

--- a/packages/villus/src/utils/common.ts
+++ b/packages/villus/src/utils/common.ts
@@ -1,5 +1,5 @@
 import { getCurrentInstance, inject, InjectionKey, isReactive, isRef, Ref, toRefs, WatchSource } from 'vue';
-import { getActiveClient, setActiveClient } from '../client';
+import { getActiveClient, setActiveClient, Client } from '../client';
 
 export function toWatchableSource<T = any>(value: Ref<T> | Record<string, any>): WatchSource | WatchSource[] {
   if (isRef(value)) {
@@ -17,8 +17,7 @@ export function toWatchableSource<T = any>(value: Ref<T> | Record<string, any>):
 
 // Uses same component provide as its own injections
 // Due to changes in https://github.com/vuejs/vue-next/pull/2424
-// todo: maybe better to modify func name and add manual client args here
-export function resolveClient(): Client {
+export function resolveClient<T>(symbol: InjectionKey<T>): Client {
   const vm = getCurrentInstance() as any;
   let client = vm && inject(symbol, vm?.provides?.[symbol as any]);
 
@@ -26,7 +25,9 @@ export function resolveClient(): Client {
   client = getActiveClient();
 
   if (client === null || client === undefined) {
-    throw new Error('Cannot detect villus Client, did you forget to call `useClient`?');
+    throw new Error(
+      'Cannot detect villus Client, did you forget to call `useClient`? Alternatively, you can explicitly pass a client as the `manualClient` argument.'
+    );
   }
 
   return client;

--- a/packages/villus/src/utils/common.ts
+++ b/packages/villus/src/utils/common.ts
@@ -18,7 +18,7 @@ export function toWatchableSource<T = any>(value: Ref<T> | Record<string, any>):
 // Uses same component provide as its own injections
 // Due to changes in https://github.com/vuejs/vue-next/pull/2424
 // todo: maybe better to modify func name and add manual client args here
-export function injectWithSelf<T>(symbol: InjectionKey<T>, onMissing: () => Error): T {
+export function resolveClient(): Client {
   const vm = getCurrentInstance() as any;
   let client = vm && inject(symbol, vm?.provides?.[symbol as any]);
 

--- a/packages/villus/src/utils/common.ts
+++ b/packages/villus/src/utils/common.ts
@@ -26,7 +26,7 @@ export function resolveClient(): Client {
   client = activeClient;
 
   if (client === null || client === undefined) {
-    throw onMissing();
+    throw new Error('Cannot detect villus Client, did you forget to call `useClient`?');
   }
 
   return client;


### PR DESCRIPTION
I'd love to use useQuery, useMutation, but we only can define it in setup. so I extended it to use outside of setup and component. The idea to extends comes from [pinia](https://pinia.vuejs.org).

I create a sampe here: https://stackblitz.com/edit/vue-9ebjy6?file=src/App.vue , and this commit should enable it.

something should be notice:
- add a new choice param(`manualClient`) in useQuery etc, to enable these function outside of component. eg: before app mounted.  We can manually send the created client to enable it.
- when useSubscription outside of setup, due to unable register beforeUnmounted, It is recommended to pause it by user.

This commit should fix https://github.com/logaretm/villus/issues/149;

hope it will be help.