### PR TITLE
Fix bug where calling `query.unwatchVariables()` can error

### DIFF
--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -107,7 +107,7 @@ function useQuery<TData = any, TVars = QueryVariables>(
   }
 
   let stopVarsWatcher: ReturnType<typeof watch>;
-  const isWatchingVariables: Ref<boolean> = ref(true);
+  const isWatchingVariables: Ref<boolean> = ref(false);
 
   function beginWatchingVars() {
     let oldCache: number;


### PR DESCRIPTION
If there are no variables passed to the query, or if the variables aren't watchable,
`isWatchingVariables.value` will be true, but `stopVarsWatcher` won't be defined,
causing `query.unwatchVariables()` to throw an error when called.

Setting the default value of the `isWatchingVariables` ref to `false` by default fixes
this, as it's set to true when `beginWatchVars` is called if the vars are watched.

For reference, the reason I'm calling `unwatchVariables` on a query where the 
variables aren't being watched anyway is I'm wrapping my villus queries in a hook
which stops the variables from being watched when the component isn't on
screen (I'm using ionic, it's complicated).