### PR TITLE
opContext.credentials in fetch object in the batch plugin

### DIFF
--- a/packages/batch/src/index.ts
+++ b/packages/batch/src/index.ts
@@ -41,6 +41,7 @@ export function batch(opts?: Partial<BatchOptions>) {
           headers: {
             ...opContext.headers,
           },
+          credentials: opContext.credentials,
           body,
         }).then(parseResponse);
 


### PR DESCRIPTION
This adds the ability to use `opContext.credentials` in the batch plugin.