### PR TITLE
docs: fix tables, and various spelling/grammar issues

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -1,8 +1,9 @@
-import { defineConfig } from 'astro/config';
-import vue from '@astrojs/vue';
-import sitemap from '@astrojs/sitemap';
-import mdx from '@astrojs/mdx';
-import highlight from './highlight';
+import { defineConfig } from "astro/config"
+import remarkGfm from "remark-gfm"
+import mdx from "@astrojs/mdx"
+import sitemap from "@astrojs/sitemap"
+import vue from "@astrojs/vue"
+import highlight from "./highlight"
 
 // https://astro.build/config
 export default defineConfig({
@@ -11,7 +12,7 @@ export default defineConfig({
     vue(),
     sitemap(),
     mdx({
-      remarkPlugins: [highlight],
+      remarkPlugins: [remarkGfm, highlight],
     }),
   ],
 });

--- a/docs/src/pages/api/client.mdx
+++ b/docs/src/pages/api/client.mdx
@@ -5,7 +5,7 @@ title: Client
 
 # Client API Reference
 
-This is a detailed documented of the villus client
+This is a detailed document of the villus client
 
 ## API Reference
 
@@ -67,9 +67,9 @@ app.use(client);
 
 ### Queries
 
-First you need to build the client instance, which can be done using `createClient` function exported by `villus`:
+First, you'll need to build the client instance, which can be done using `createClient` function exported by `villus`:
 
-Then you can run queries, mutations or subscriptions using any of their corresponding methods.
+Then you can run queries, mutations, or subscriptions using any of their corresponding methods.
 
 You can execute queries using `executeQuery` method on the client instance:
 
@@ -147,7 +147,7 @@ You can make use of `async/await` as `executeQuery` and `executeMutation` both r
 
 ### Subscriptions
 
-Subscriptions are trickier, because they are more **event-driven**, so you cannot wait for them to execute like queries or mutations. Because of this, the `executeSubscription` method returns an **Observable** that allows you respond to incoming data.
+Subscriptions are trickier because they are more **event-driven**, so you cannot wait for them to execute like queries or mutations. Because of this, the `executeSubscription` method returns an **Observable** that allows you to respond to incoming data.
 
 The `useSubscription` function offers an abstraction for dealing with subscriptions but you can still execute your own arbitrary subscriptions without resorting to either:
 

--- a/docs/src/pages/api/use-mutation.mdx
+++ b/docs/src/pages/api/use-mutation.mdx
@@ -51,6 +51,6 @@ const { data, execute } = useMutation(LikePost);
 
 ## Reactivity
 
-useMutation does not accept reactive queries or variables, so it is your responsibility to unwrap any reactive values passed to it
+`useMutation` does not accept reactive queries or variables, so it is your responsibility to unwrap any reactive values passed to it
 
 For more information on `useMutation`, [check the mutations guide](/guide/mutations)/

--- a/docs/src/pages/api/use-query.mdx
+++ b/docs/src/pages/api/use-query.mdx
@@ -60,7 +60,7 @@ const { data, error } = useQuery({
 
 ### Query Options
 
-This is the full object fields that the `useQuery` function accepts:
+These are the full object fields that the `useQuery` function accepts:
 
 | Property     | Type                                                                                         | Required | Description                                                                                                                                                                                                                   |
 | ------------ | -------------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -70,7 +70,7 @@ This is the full object fields that the `useQuery` function accepts:
 | fetchOnMount | `boolean`                                                                                    | **No**   | If the query **should be** executed on `mounted`, default is `true`                                                                                                                                                           |
 | context      | `{ headers: Record<string, string> }`                                                        | **No**   | A object to be merged with the fetch options, currently accepts `headers`. The `context` can be a reactive `ref` or `computed ref`.                                                                                           |
 | paused       | `boolean` or `Ref<boolean>` or `(variables?: TVars) => boolean`                              | **No**   | When `true` it will pause executing the query when the variables change. If it is a reactive or a function and it changes back to `false` it will re-execute the query automatically if no execution was already in progress. |
-| skip         | `Ref<boolean>` or `(variables?: TVars) => boolean`                                           | **No**   | When `true` any execution calls will be prevented. Similar to `paused` except it doesn't trigger any automatic executions when it changes.                                                                                    |
+| skip         | `Ref<boolean>` or `(variables?: TVars) => boolean`                                           | **No**   | When `true` any execution calls will be prevented. Similar to `paused`, except it doesn't trigger any automatic executions when it changes.                                                                                    |
 
 This signature allows you to tweak the `fetchOnMount` and `cachePolicy` behaviors for the query, Here is an example:
 

--- a/docs/src/pages/api/use-subscription.mdx
+++ b/docs/src/pages/api/use-subscription.mdx
@@ -15,7 +15,7 @@ The `useSubscription` function returns the following properties and functions:
 | -------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | data     | `Ref<any/null>`        | The GraphQL subscription result's `data`                                                                                 |
 | error    | `Ref<CombinedError>`   | Any errors encountered during subscription execution                                                                     |
-| paused   | `ComputedRef<boolean>` | True if the subscription is paused or inactive. This is readonly and you should control it by the passed `paused` value. |
+| paused   | `ComputedRef<boolean>` | True if the subscription is paused or inactive. This is readonly, and you should control it by the passed `paused` value. |
 
 ## Usage
 
@@ -27,7 +27,7 @@ The `useSubscription` function accepts two arguments, the first being the operat
 | variables | `object` or `Ref<object>`                   | **No**          | The subscription variables      |
 | paused    | `Ref<boolean>`                              | `() => boolean` | **No**                          | If the subscription should be paused, if `true` any incoming values will be ignored by the reducer |
 
-The second argument is what is called a `Reducer` which allows you aggregate subscription results. For more information about that, [check the subscription guide](/guide/subscriptions).
+The second argument is what is called a `Reducer` which allows you to aggregate subscription results. For more information about that, [check the subscription guide](/guide/subscriptions).
 
 Here is a full example of the usage:
 

--- a/docs/src/pages/examples/basic-query.mdx
+++ b/docs/src/pages/examples/basic-query.mdx
@@ -7,7 +7,7 @@ order: 1
 
 # Query Example
 
-This is a simple example for how to run queries along with reactive variables
+This is a simple example of how to run queries along with reactive variables
 
 <p class="codepen" data-height="625" data-theme-id="light" data-default-tab="js,result" data-user="logaretm" data-slug-hash="eYZbevO" style="height: 625px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Basic Queries">
   <span>See the Pen <a href="https://codepen.io/logaretm/pen/eYZbevO">

--- a/docs/src/pages/examples/state-store-pinia.mdx
+++ b/docs/src/pages/examples/state-store-pinia.mdx
@@ -7,7 +7,7 @@ order: 3
 
 # Queries in a state store
 
-There are multiple ways you can query in a state store. For example, [Pinia](https://pinia.vuejs.org/) allows you to define stores as a smaller setup functions. This allows you to use `useQuery` or `useMutation` features directly in your store as state or actions.
+There are multiple ways you can query in a state store. For example, [Pinia](https://pinia.vuejs.org/) allows you to define stores as smaller setup functions. This allows you to use `useQuery` or `useMutation` features directly in your store as state or actions.
 
 The following example showcases a store created using `useQuery` where it fetches the data from the API and shows a loading state as well.
 

--- a/docs/src/pages/guide/mutations.mdx
+++ b/docs/src/pages/guide/mutations.mdx
@@ -9,13 +9,13 @@ order: 4
 
 ## Mutations Basics
 
-**villus** offers a `useMutation` function that os very similar to its **[querying](/queries.md)** counterpart but with few distinct differences:
+**villus** offers a `useMutation` function that is very similar to its **[querying](/queries.md)** counterpart but with few distinct differences:
 
 - It **does not** accept a `variables` option.
 - It **does not** execute automatically, you have to explicitly call `execute`.
 - Cache policies do not apply to mutations as mutations represent user actions and will always use `network-only` policy.
 
-Here is an example for the `useMutation` function:
+Here is an example of the `useMutation` function:
 
 ```vue
 <template>

--- a/docs/src/pages/guide/overview.mdx
+++ b/docs/src/pages/guide/overview.mdx
@@ -8,9 +8,9 @@ order: 1
 
 villus is a minimal [GraphQL](https://graphql.org/) client for Vue.js, exposing components to build highly customizable GraphQL projects. You can use this in small projects or large complex applications.
 
-I use GraphQL In most of the apps I build, but more often than not I end up only using the bare-bones **ApolloLink** without the extra whistles provided by the **ApolloClient**. I often even just use a bare `fetch` to run my GraphQL queries as I prefer to handle caching and persisting on my own when building complex PWA apps. Also the fact that Apollo Client sometimes throws obscure non-standard GraphQL errors doesn't help.
+I use GraphQL In most of the apps I build, but more often than not I end up only using the bare-bones **ApolloLink** without the extra whistles provided by the **ApolloClient**. I often even just use a bare `fetch` to run my GraphQL queries as I prefer to handle caching and persisting on my own when building complex PWA apps. Also, the fact that Apollo Client sometimes throws obscure non-standard GraphQL errors doesn't help.
 
-To solve this, I needed a bare-bones GraphQL client for Vue.js, but with small quality of life defaults out of the box, like caching. Keeping it simple means it gets to be flexible and lightweight, and can be scaled to handle more complex challenges.
+To solve this, I needed a bare-bones GraphQL client for Vue.js, but with small quality of life defaults out of the box, like caching. Keeping it simple means it gets to be flexible, lightweight, and can be scaled to handle more complex challenges.
 
 This library is inspired by [URQL](https://github.com/FormidableLabs/urql), and forked from my past contribution to the `vue-gql` library before a different direction was decided for it.
 

--- a/docs/src/pages/guide/plugins.mdx
+++ b/docs/src/pages/guide/plugins.mdx
@@ -14,7 +14,7 @@ villus is very flexible and versatile, and as such you will need to write quite 
 Something you might not be aware of is that villus is pre-configured with a couple of plugins that are necessary to execute queries, the default plugins are:
 
 - [`fetch`](/plugins/fetch): used to execute queries on the network (actual fetching)
-- [`cache`](/plugins/cache): an in-memory simple cache that comes with villus by default, supports all cache policies
+- [`cache`](/plugins/cache): an in-memory simple cache that comes with villus by default, and supports all cache policies
 - [`dedup`](/plugins/dedup): removes any duplicate pending queries
 
 Furthermore, villus exposes the default plugins as `defaultPlugins` function. To add plugins to villus client you need to pass a `use` array containing the plugins you would like to have
@@ -41,8 +41,8 @@ In addition to the default plugins, villus also offers the following plugins but
 Under the hood, plugins are simple callbacks that run through various life-cycles of the operation execution, the main features of villus plugins compared to other libraries are:
 
 - All plugins can be synchronous or asynchronous
-- They will be executed at the same order they are defined in
-- Each plugin can set anything about the current operation fetch options, like `url` or `body` or `headers` (ex: adding auth token to headers)
+- They will be executed in the same order they are defined in
+- Each plugin can set anything about the current operations fetch options, like `url` or `body` or `headers` (ex: adding auth token to headers)
 - Each plugin can choose to set the operation result at any time without stopping other plugins (ex: cache plugins)
 - Each plugin can choose to end the operation with a specific result while skipping other plugins by setting the terminate signal (ex: fetch and batch plugins)
 - Each plugin can execute a callback that's synchronous or asynchronous after the query is executed (ex: cache plugin)
@@ -83,11 +83,11 @@ The following sections will explain the purpose of each item in the context
 
 ### useResult()
 
-The `useResult` function allows your plugin to resolve a value for the GraphQL operation. Plugins like `fetch`, `batch` and `cache` make use of this as each of them is responsible for setting a response value for the GraphQL operation.
+The `useResult` function allows your plugin to resolve a value for the GraphQL operation. Plugins like `fetch`, `batch`, and `cache` make use of this as each of them are responsible for setting a response value for the GraphQL operation.
 
 #### Non-terminating Results
 
-There is two types of `useResult` calls, the first being a **non-terminating** resolution, meaning that while your plugin found a value, it still wants other plugins to continue executing:
+There are two types of `useResult` calls, the first being a **non-terminating** resolution, meaning that while your plugin found a value, it still wants other plugins to continue executing:
 
 ```js
 useResult(response); // Other plugins will still execute
@@ -97,7 +97,7 @@ This is useful for the `cache` plugin with the `cache-and-network` policy as it 
 
 #### Terminating Results
 
-The other type is a **terminating** resolution, meaning your plugin has decided to take over the pipeline and stop executing all others. This is useful with the `cache` plugin, because with the `cache-first` policy, it doesn't want any requests to go through.
+The other type is a **terminating** resolution, meaning your plugin has decided to take over the pipeline and stop executing all others. This is useful with the `cache` plugin because with the `cache-first` policy, it doesn't want any requests to go through.
 
 ```js
 useResult(response, true); // Stops all plugins after it
@@ -105,7 +105,7 @@ useResult(response, true); // Stops all plugins after it
 
 <DocTip>
 
-Calling `useResult` multiple times in the pipeline (by multiple plugins) won't have an effect on the end result, the very first `useResult` call will set the operation response, any subsequent calls are ignored.
+Calling `useResult` multiple times in the pipeline (by multiple plugins) won't have an effect on the end result as the very first `useResult` call will set the operation response, and any subsequent calls are ignored.
 
 </DocTip>
 
@@ -113,7 +113,7 @@ Calling `useResult` multiple times in the pipeline (by multiple plugins) won't h
 
 The `afterQuery` function allows you to run a callback after the query is finished, the callback receives the GraphQL response as the first argument.
 
-For example the `cache` plugin makes use of this to cache the operation response, here is an snippet of what happens in the `cache` plugin:
+For example, the `cache` plugin makes use of this to cache the operation response, here is a snippet of what happens in the `cache` plugin:
 
 ```js
 function cachePlugin({ afterQuery, useResult, operation }) {
@@ -126,7 +126,7 @@ function cachePlugin({ afterQuery, useResult, operation }) {
 }
 ```
 
-Additionally you can have access to the actual response returned by the `fetch` API, the second argument is an object that contains the `response` property:
+Additionally, you can have access to the actual response returned by the `fetch` API, the second argument is an object that contains the `response` property:
 
 ```js
 function somePlugin({ afterQuery, useResult, operation }) {
@@ -147,7 +147,7 @@ The `operation` field contains useful information about the GraphQL operation be
 | ----------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
 | query       | `string \| DocumentNode`                                                 | The query/mutation being executed                                                     |
 | variables   | `Record<string, any>`                                                    | The query variables passed with the operation                                         |
-| cachePolicy | `'cache-first' \| 'network-only' \| 'cache-and-network' \| 'cache-only'` | The cache policy for this operation, useful if you are building a custom cache plugin |
+| cachePolicy | `'cache-first' \| 'network-only' \| 'cache-and-network' \| 'cache-only'` | The cache policy for this operation, which is useful if you are building a custom cache plugin |
 | key         | `number`                                                                 | A unique identifier to use for this operation, useful for cache and dedup plugins     |
 | type        | `'query' \| 'mutation' \| 'subscription'`                                | The operation type                                                                    |
 
@@ -155,7 +155,7 @@ The `operation` field contains useful information about the GraphQL operation be
 
 The `opContext` field is the `fetch` options that will be passed to the `fetch` or `batch` plugins or your custom plugin that makes the actual request, it has the same shape as [`RequestInit` interface](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#Parameters). This is particularly useful if you are building a `fetch` plugin or some kind of authentication plugin with headers or cookies.
 
-Here is a few useful snippets:
+Here are a few useful snippets:
 
 ```js
 function myPlugin({ opContext, operation }) {
@@ -178,7 +178,7 @@ All plugins are processed in the same order they were added in, and as you can i
 
 ## Plugin Configuration
 
-You might want to create a configurable plugin to publish or re-use in various ways. `villus` doesn't really offer any API for that but good old higher-order functions can be used to achieve that:
+You might want to create a configurable plugin to publish or re-use in various ways. `villus` doesn't offer any API for that but good old higher-order functions can be used to achieve that:
 
 ```js
 function myPluginWithConfig({ prefix }) {
@@ -212,7 +212,7 @@ const myPluginWithConfig = (config: { prefix: string }) => {
 
 ## Example - Adding Authorization Headers
 
-It's very likely you have a authentication header you would like to add to your queries to be able to execute protected queries/mutations. A very common header is `Authorization` header which contains an auth token. Here is a snippet that shows how to add such headers to your queries:
+You likely have an authentication header you would like to add to your queries to be able to execute protected queries/mutations. A very common header is `Authorization` header which contains an auth token. Here is a snippet that shows how to add such headers to your queries:
 
 ```js
 function authPlugin({ opContext }) {
@@ -232,11 +232,11 @@ And that's it,
 
 ## Example - Persistent Cache
 
-You might want to create a custom cache especially that villus default cache plugin does not persist when the page is reloaded or when the client is destroyed, this is because villus default cache is a simple object in memory that keeps track of queries during runtime and each time the page is reloaded or when the client is initialized, it will start with a new object each time. This is convenient for most cases but you might want to leverage a more permanent cache solution.
+You might want to create a custom cache especially since the villus default cache plugin does not persist when the page is reloaded or when the client is destroyed, this is because villus default cache is a simple object in memory that keeps track of queries during runtime and each time the page is reloaded or when the client is initialized, it will start with a new object each time. This is convenient for most cases but you might want to leverage a more permanent cache solution.
 
-In our example we will use `localStorage` as our storage to cache queries, you are free to use anything else as a storage like [`indexedDB`](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) which should offer more powerful capabilities and flexibility.
+In our example we will use `localStorage` as our storage to cache queries, you are free to use anything else as storage like [`indexedDB`](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) which should offer more powerful capabilities and flexibility.
 
-Here is an example of such cache:
+Here is an example of such a cache:
 
 ```js
 function localStorageCache({ afterQuery, useResult, operation }) {
@@ -329,13 +329,13 @@ If you are using an error reporting or bug tracking service like [`Sentry`](http
 
 It would be useful to handle most of the errors in a global handler while leaving the specific errors (e.g: validation) to the component that used that query/mutation.
 
-In this example, a global error handler is created where it reports all 500 and unknown errors to sentry.
+In this example, a global error handler is created where it reports all 500 (and unknown) errors to Sentry.
 
 ```ts
 import { captureException } from '@sentry/browser';
 
 /**
- * Reports unknown errors to sentry to avoid having to do that ever where.
+ * Reports unknown errors to Sentry to avoid having to do that everywhere.
  */
 const sentryReportPlugin = definePlugin(({ operation, afterQuery }) => {
   afterQuery(({ error }, { response }) => {

--- a/docs/src/pages/guide/queries.mdx
+++ b/docs/src/pages/guide/queries.mdx
@@ -13,7 +13,7 @@ You can query GraphQL APIs with the `useQuery` composition function after you've
 
 ## Queries Basics
 
-The `useQuery` function is a composable function that provides query state and various helper methods around managing the query.
+The `useQuery` function is a composable function that provides query state and various helper methods for managing the query.
 
 To execute a query the `useQuery` accepts a GraphQL query as the first argument. The `query` property is a `string` containing the query body or a `DocumentNode` (AST) created by `graphql-tag`.
 
@@ -48,7 +48,7 @@ const { data } = useQuery({
 
 You can use `graphql-tag` to compile your queries or load them with the `graphql-tag/loader`.
 
-This a sample with the `useQuery` function:
+This is an example with the `useQuery` function:
 
 ```vue
 <script setup>
@@ -102,7 +102,7 @@ const { data } = useQuery({
 </script>
 ```
 
-However if you want to re-fetch the query whenever the variables change, then this is where the composition API shines. You can pass a [reactive object](https://v3.vuejs.org/api/basic-reactivity.html#reactive) containing your variables and the query will automatically execute with the new variables value:
+However, if you want to re-fetch the query whenever the variables change, then this is where the composition API shines. You can pass a [reactive object](https://v3.vuejs.org/api/basic-reactivity.html#reactive) containing your variables and the query will automatically execute with the new variables value:
 
 ```vue
 <script setup>
@@ -151,7 +151,7 @@ const { data } = useQuery({
 </script>
 ```
 
-This is only one way to re-fetch queries, because `villus` is built with composable API first you will find many ways to re-fetch your queries no matter how complex your requirements are.
+This is only one way to re-fetch queries because `villus` is built with composable API first you will find many ways to re-fetch your queries no matter how complex your requirements are.
 
 ## Re-fetching Queries
 
@@ -174,7 +174,7 @@ execute();
 </script>
 ```
 
-This can be very useful in situations where you have a complex logic that triggers a refetch, that means `watch` and `watchEffect` play really well with the `execute` function:
+This can be very useful in situations where you have complex logic that triggers a refetch, which means `watch` and `watchEffect` play well with the `execute` function:
 
 ```vue
 <script setup>
@@ -259,7 +259,7 @@ const { data } = useQuery({
 </script>
 ```
 
-The previous example can be also re-written like this, since the `paused` function receives the current variables as an argument.
+The previous example can be also re-written as shown below, since the `paused` function receives the current variables as an argument.
 
 ```vue
 <script setup>
@@ -301,7 +301,7 @@ function runQuery() {
 </script>
 ```
 
-Whenever the `paused` is a reactive value and it changes to `false`, the query will be re-executed automatically so you can also use `paused` to wait for when some condition is met before the query is executed. For example maybe you have a query that depends on another and want to make sure not to fetch the second one unless the first one was fetched.
+Whenever the `paused` is a reactive value and it changes to `false`, the query will be re-executed automatically so you can also use `paused` to wait for when some condition is met before the query is executed. For example, maybe you have a query that depends on another and would like to make sure not to fetch the second one unless the first one was fetched.
 
 ```vue
 <script setup>
@@ -342,9 +342,9 @@ const { data } = useQuery({
 
 ## Skipping Queries
 
-You can also skip executing queries by providing a `skip` argument to the query options. This can be particularly useful if you want to prevent fetching or refetching a query if a variable value is invalid. This may seem similar to `paused` except it doesn't stop query or variables watching and it prevents all executions, even manual ones with `execute`. Also it doesn't re-fetch automatically whenever it is set back to `false`.
+You can also skip executing queries by providing a `skip` argument to the query options. This can be particularly useful if you want to prevent fetching or refetching a query if a variable value is invalid. This may seem similar to `paused` except it doesn't stop query or variables watching and it prevents all executions, even manual ones with `execute`. Also, it doesn't re-fetch automatically whenever it is set back to `false`.
 
-In the following example we skip the query unless the user has entered enough characters for the search terms.
+In the following example, we skip the query unless the user has entered enough characters for the search terms.
 
 ```vue
 <template>
@@ -433,7 +433,7 @@ const { data, isFetching } = useQuery({
 </script>
 ```
 
-Of course you could've used `paused` for the previous example, but because `paused` stops watching the query variables it means you query won't trigger whenever the user type something into the search terms. Also it wouldn't work correctly if you call `execute` manually with a watcher because `paused` doesn't stop manual executions. This makes `skip` ideal for situations where you want to keep the reactivity of the query while also ignoring certain executions of it.
+Of course, you could've used `paused` for the previous example, but because `paused` stops watching the query variables it means your query won't trigger whenever the user type something into the search terms. Also, it wouldn't work correctly if you call `execute` manually with a watcher because `paused` doesn't stop manual executions. This makes `skip` ideal for situations where you want to keep the reactivity of the query while also ignoring certain executions of it.
 
 ## Fetching on Mounted
 
@@ -474,7 +474,7 @@ By default the client uses `cache-first` policy to handle queries, the full list
 
 - `cache-first`: If found in cache return it, otherwise fetch it from the network
 - `network-only`: Always fetch from the network and do not cache it
-- `cache-and-network`: If found in cache return it, then fetch a fresh result from the network and update current data (reactive). if not found in cache it will fetch it from network and cache it
+- `cache-and-network`: If found in cache return it, then fetch a fresh result from the network and update current data (reactive). if not found in cache, it will fetch it from the network and cache it
 - `cache-only`: If found in cache return it, otherwise returns `null` for both `data` and `errors`
 
 You can specify a different strategy on different levels:
@@ -650,10 +650,10 @@ const { data, isFetching } = useQuery({
 </script>
 ```
 
-Whenever a re-fetch is triggered, or the query was executed again the `isFetching` will be updated accordingly so you don't have to keep it in sync with anything nor you have to create your own boolean refs for indications.
+Whenever a re-fetch is triggered, or the query was executed again, the `isFetching` property will update accordingly so you don't have to keep it in sync, nor will you have to create your own boolean refs for indications.
 
 <DocTip title="Initial isFetching value">
 
-Is fetching default value is `true` if `fetchOnMount` is enabled, otherwise it will start off with `false`.
+The default value for `isFetching` is `true` if `fetchOnMount` is enabled, otherwise it will default to `false`.
 
 </DocTip>

--- a/docs/src/pages/guide/setup.mdx
+++ b/docs/src/pages/guide/setup.mdx
@@ -49,7 +49,7 @@ app.use(client);
 
 ## Multiple Providers
 
-While uncommon, there is no limitations on how many endpoints you can use within your app, you can use as many clients as you like and that allows you to query different GraphQL APIs within the same app without hassle.
+While uncommon, there are no limitations on how many endpoints you can use within your app, you can use as many clients as you like, and that allows you to query different GraphQL APIs within the same app without hassle.
 
 To do that you will need to create a parent component for each client:
 
@@ -71,4 +71,4 @@ useClient({
 
 ## Next Steps
 
-Now that you have successfully setup the GraphQL client, you can start to [query](/guide/queries) and [execute mutations](/guide/mutations) on your GraphQL APIs.
+Now that you have successfully set up the GraphQL client, you can start to [query](/guide/queries) and [execute mutations](/guide/mutations) on your GraphQL APIs.

--- a/docs/src/pages/guide/subscriptions.mdx
+++ b/docs/src/pages/guide/subscriptions.mdx
@@ -31,10 +31,10 @@ const client = useClient({
 </script>
 ```
 
-Once you've setup the `handleSubscriptions` plugin, you can now use the `useSubscription` function.
+Once you've set up the `handleSubscriptions` plugin, you can now use the `useSubscription` function.
 
 <DocTip>
-  
+
 You can also use [`graphql-ws`](https://github.com/enisdenjo/graphql-ws) package for your subscriptions, but you will need to modify your `subscriptionForwarder` to look like this:
 
 ```vue
@@ -128,7 +128,7 @@ const { data } = useSubscription({
 
 ## Handling Subscription Data
 
-The previous examples are not very useful as usually you would like to be able to use the `data` as a continuos value rather than a reference to the last received value, that is why you can pass a custom reducer as the second argument to the `useSubscription` function, think of it as a subscription handler that aggregates the results into a single value. The aggregated value will become the `data` returned from `useSubscription`.
+The previous examples are not very useful, as usually you would like to be able to use the `data` as a continuous value rather than a reference to the last received value, that is why you can pass a custom reducer as the second argument to the `useSubscription` function, think of it as a subscription handler that aggregates the results into a single value. The aggregated value will become the `data` returned from `useSubscription`.
 
 Here is the last example with a custom reducer, we will be covering the `setup` function only since the rest of the component is mostly the same:
 
@@ -168,7 +168,7 @@ The `reduceMessages` function acts as a reducer for the incoming data, whenever 
 
 <DocTip>
 
-Keep in mind that initially we have `null` for the initial value so we needed to provide a fallback for that.
+Keep in mind that initially, we have `null` for the initial value so we needed to provide a fallback for that.
 
 </DocTip>
 

--- a/docs/src/pages/guide/testing.mdx
+++ b/docs/src/pages/guide/testing.mdx
@@ -80,13 +80,13 @@ The next step would be to mock the response the component expects from the API. 
 - Mock the `fetch` function and have it return the response
 - Use an advanced mocking library like [mswjs](https://mswjs.io/) to mock an API server
 
-While the former can be simpler, It is recommended to go with the mswjs approach since it allows you to test GraphQL error responses and it allows you to test your component in an environment that's much closer to real-world.
+While the former can be simpler, It is recommended to go with the mswjs approach as it allows you to test GraphQL error responses and it allows you to test your component in an environment that's much closer to real-world.
 
 This guide won't focus on how to do either of these methods, but it is recommended to go with mswjs.
 
 ## Writing Assertions
 
-Assuming you've set up your network request mocked environment, the next step would be writing the actual assertion to make sure the component does its job.
+Assuming you've set up your network request-mocked environment, the next step would be writing the actual assertion to make sure the component does its job.
 
 Here is some assertions that test if the component fetches the data when mounted and displays the posts returned from the API:
 

--- a/docs/src/pages/guide/typescript-codgen.mdx
+++ b/docs/src/pages/guide/typescript-codgen.mdx
@@ -9,7 +9,7 @@ order: 7
 
 `villus` is built with TypeScript in its core, you can provide typings for your fetched queries and their variables.
 
-Providing typings manually for your queries and variables can be as straight forward as this:
+Providing typings manually for your queries and variables can be as straightforward as this:
 
 ```ts
 import { useQuery } from 'villus';
@@ -41,11 +41,11 @@ const { data } = useQuery<PostsQuery, PostsVariables>({
 data.value; // is now typed as PostsQuery type!
 ```
 
-This however simple it is, it can be very tedious and will be hard to maintain as your schema evolve with time. Which is why it is better to automatically generate them with [GraphQL code generator](https://graphql-code-generator.com/).
+However, it can be very tedious (and will be hard to maintain) as your schema evolves with time. This is why it is better to automatically generate them with [GraphQL code generator](https://graphql-code-generator.com/).
 
 ## Automatically Generating Types
 
-The [GraphQL code generator](https://graphql-code-generator.com/) tool allow you to configure automation to generate the TypeScript definitions for your schema, queries, mutations and their variables.
+The [GraphQL code generator](https://graphql-code-generator.com/) tool allows you to configure automation to generate the TypeScript definitions for your schema, queries, mutations, and their variables.
 
 Make to read their [documentation](https://graphql-code-generator.com/docs/getting-started/index) to get familiar with the setup and tools you will need, this guide will focus on the relevant parts of `villus`.
 
@@ -87,7 +87,7 @@ const { data } = useQuery({
 data.value; // is now typed as PostsQuery type!
 ```
 
-This reduces the noise you have to import in your file and allow your code to be more concise.
+This reduces the noise you have to import into your file and allows your code to be more concise.
 
 ## Demo
 

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -30,11 +30,11 @@ Thanks for the following companies and individuals who are supporting villus
 
 <br />
 
-You can also help this this project and my other projects by donating one time or by sponsoring via the following link
+You can also help this project and my other projects by donating one time or by sponsoring via the following link
 
 <br />
 
-<div class="flex justify-center items-center">
+<div class="flex items-center justify-center">
   <sponsor-button></sponsor-button>
 </div>
 
@@ -42,7 +42,7 @@ You can also help this this project and my other projects by donating one time o
 
 ## Quick Start
 
-First install `villus`
+First, install `villus`
 
 yarn
 

--- a/docs/src/pages/plugins/batch.mdx
+++ b/docs/src/pages/plugins/batch.mdx
@@ -15,7 +15,7 @@ The batch plugin is available as its own package under the name `@villus/batch`
 
 ## Basic Batching
 
-First add the plugin to your dependencies using `yarn` or `npm`:
+First, add the plugin to your dependencies using `yarn` or `npm`:
 
 ```bash
 yarn add @villus/batch
@@ -87,7 +87,7 @@ This will add a `50ms` time window between queries to be batched together.
 
 ## Batched operations limit
 
-You can also introduce a limit on how many operations can be executed in a batch. Usually this is a good idea to make sure you don't include a lot of operations in a single batch which could have inverse effect on performance since the total execution time now depends on all the operations being executed.
+You can also introduce a limit on how many operations can be executed in a batch. Usually, it is a good idea to make sure you don't include a lot of operations in a single batch which could have an inverse effect on performance since the total execution time now depends on all the operations being executed.
 
 You can configure the batch limit by passing a `maxOperationCount` option to the `batch` function configuration:
 
@@ -103,7 +103,7 @@ useClient({
 </script>
 ```
 
-By default it is `10`.
+By default, it is `10`.
 
 ## Options
 

--- a/docs/src/pages/plugins/cache.mdx
+++ b/docs/src/pages/plugins/cache.mdx
@@ -15,7 +15,7 @@ The cache plugin handles all the cache policies in villus:
 
 - `cache-first`: If found in cache return it, otherwise fetch it from the network
 - `network-only`: Always fetch from the network and do not cache it
-- `cache-and-network`: If found in cache return it, then fetch a fresh result from the network and update current data (reactive). if not found in cache it will fetch it from network and cache it
+- `cache-and-network`: If found in cache return it, then fetch a fresh result from the network and update current data (reactive). if not found in cache it will fetch it from the network and cache it
 - `cache-only`: If found in cache return it, otherwise returns an empty response without errors
 
 ```vue

--- a/docs/src/pages/plugins/dedup.mdx
+++ b/docs/src/pages/plugins/dedup.mdx
@@ -11,7 +11,7 @@ import DocTip from '@/components/DocTip.vue';
 
 The dedup plugin removes any duplicate pending queries from executing which means you can safely run the same queries at the same time without worrying about excessive requests.
 
-The dedup plugin only applies it's caching logic to queries. Mutations and subscriptions are excluded from the deduplication process.
+The dedup plugin only applies its caching logic to queries. Mutations and subscriptions are excluded from the deduplication process.
 
 ```vue
 <script setup>

--- a/docs/src/pages/plugins/fetch.mdx
+++ b/docs/src/pages/plugins/fetch.mdx
@@ -11,7 +11,7 @@ import DocTip from '@/components/DocTip.vue';
 
 The fetch plugin is both a very simple plugin and a critical one to villus inner workings. Because villus is built using a pipeline of plugins that perform some processing on a GraphQL operation.
 
-The fetch plugin is the one that actually executes your queries and mutations against the GraphQL API which is why it is very important to either have a `fetch` or `batch` plugins or any similar plugins you may write on your own.
+The fetch plugin is the one that executes your queries and mutations against the GraphQL API which is why it is very important to either have a `fetch` or `batch` plugin, or any similar plugins you may write on your own.
 
 <DocTip>
 

--- a/docs/src/pages/plugins/handle-subscriptions.mdx
+++ b/docs/src/pages/plugins/handle-subscriptions.mdx
@@ -7,7 +7,7 @@ order: 6
 
 # Handle Subscriptions Plugin
 
-Subscriptions are very different from queries or mutations, as it is considered a constant stream of events or data. Because of this it requires special handling, `villus` implements the subscriptions support as a plugin for added flexibility and streamlining the query execution process regardless of its type.
+Subscriptions are very different from queries or mutations, as it is considered a constant stream of events or data. Because of this, it requires special handling, `villus` implements the subscription support as a plugin for added flexibility and streamlining of the query execution process regardless of its type.
 
 ## Options
 

--- a/docs/src/pages/plugins/multipart.mdx
+++ b/docs/src/pages/plugins/multipart.mdx
@@ -15,7 +15,7 @@ The multipart plugin is available as its own package under the name `@villus/mul
 
 ## Basic File Upload
 
-First add the plugin to your dependencies using `yarn` or `npm`:
+First, add the plugin to your dependencies using `yarn` or `npm`:
 
 ```bash
 yarn add @villus/multipart


### PR DESCRIPTION
- I noticed a few minor spelling and grammar mistakes, and figured I'd go through all of the documentation and fix anything else that stood out (turns out.. a lot 😄).
- Tables are also currently broken on the site (see below screenshot). A recent Astro update adds a `extendDefaultPlugins` configuration option to preserve default plugins, and only append additional plugins, however I wasn't sure the impact of upgrading Astro in regards to the site. I simply re-added the `remark-gfm` plugin (which is what Astro includes by default), to get tables working again.

![](https://cdn.liam.sh/share/2022/09/chrome_rgBgYLus3d.png)

And including the `remark-gfm` plugin, changes these to:
![](https://cdn.liam.sh/share/2022/09/chrome_cQAjr5ChhW.png)