### PR TITLE
Exported variable 'useCreateProFormaStore' has or is using name 'QueryExecutionOpts' but cannot be named.ts(4023)

### DIFF
--- a/packages/villus/src/index.ts
+++ b/packages/villus/src/index.ts
@@ -1,6 +1,6 @@
 export { createClient, defaultPlugins, setActiveClient, getActiveClient, ClientOptions, Client } from './client';
 export { useClient } from './useClient';
-export { useQuery, QueryApi, BaseQueryApi, QueryCompositeOptions } from './useQuery';
+export { useQuery, QueryApi, BaseQueryApi, QueryCompositeOptions, QueryExecutionOpts } from './useQuery';
 export { useMutation } from './useMutation';
 export { useSubscription, Reducer } from './useSubscription';
 export { handleSubscriptions, SubscriptionForwarder } from './handleSubscriptions';

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -24,10 +24,10 @@ export interface QueryCompositeOptions<TData, TVars> {
   skip?: QueryPredicateOrSignal<TVars>;
 }
 
-interface QueryExecutionOpts<TVars> {
+export type QueryExecutionOpts<TVars> = {
   cachePolicy: CachePolicy;
   variables: TVars;
-}
+};
 
 export interface BaseQueryApi<TData = any, TVars = QueryVariables> {
   data: Ref<TData | null>;

--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -24,10 +24,10 @@ export interface QueryCompositeOptions<TData, TVars> {
   skip?: QueryPredicateOrSignal<TVars>;
 }
 
-export type QueryExecutionOpts<TVars> = {
+export interface QueryExecutionOpts<TVars> {
   cachePolicy: CachePolicy;
   variables: TVars;
-};
+}
 
 export interface BaseQueryApi<TData = any, TVars = QueryVariables> {
   data: Ref<TData | null>;


### PR DESCRIPTION
This fixes the issue of  QueryExecutionOpts not being exported from villus.d.ts.
Simply changing to `export interface` would result in the interface still not being exported from the generated villus.d.ts, hence the change to a type.
