### PR TITLE
feat: cache eviction mechanism

### DIFF
--- a/docs/src/pages/plugins/cache.mdx
+++ b/docs/src/pages/plugins/cache.mdx
@@ -38,6 +38,29 @@ The cache plugin is one of the default plugins that are pre-configured with any 
 
 At this moment the cache plugin doesn't have any options to customize
 
+## Clearing cache
+
+You can clear the cache for all queries using `clearCache()` present on the cachePlugin instance. You can export the cache plugin to make it accessible to other parts of your code like so:
+
+```ts
+import { useClient, cache, fetch } from 'villus';
+
+export const cachePlugin = cache();
+
+useClient({
+  use: [cachePlugin, fetch()],
+});
+```
+
+Then you can import it and clear it whenever it makes sense in your logic:
+
+```ts
+import { cachePlugin } from '../client';
+
+// anywhere in your code
+cachePlugin.clearCache();
+```
+
 ## Code
 
 You can check the [source code for the `cache` plugin](https://github.com/logaretm/villus/blob/main/packages/villus/src/cache.ts) and use it as a reference to build your own

--- a/packages/villus/src/cache.ts
+++ b/packages/villus/src/cache.ts
@@ -4,7 +4,7 @@ interface ResultCache {
   [k: string]: OperationResult;
 }
 
-export function cache(): ClientPlugin & { clear(): void } {
+export function cache(): ClientPlugin & { clearCache(): void } {
   let resultCache: ResultCache = {};
 
   function setCacheResult({ key }: ClientPluginOperation, result: OperationResult) {
@@ -15,7 +15,7 @@ export function cache(): ClientPlugin & { clear(): void } {
     return resultCache[key];
   }
 
-  function clear() {
+  function clearCache() {
     resultCache = {};
   }
 
@@ -41,7 +41,7 @@ export function cache(): ClientPlugin & { clear(): void } {
     }
   }
 
-  cachePlugin.clear = clear;
+  cachePlugin.clearCache = clearCache;
 
   return cachePlugin;
 }

--- a/packages/villus/test/useQuery.spec.ts
+++ b/packages/villus/test/useQuery.spec.ts
@@ -151,7 +151,7 @@ describe('useQuery()', () => {
       expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    cache.clear();
+    cache.clearCache();
 
     document.querySelector('button')?.dispatchEvent(new Event('click'));
     await flushPromises();


### PR DESCRIPTION
# What

This PR aims to introduce a way to clear the cache and overall improve the caching mechanism offered by villus.

There have been several suggestions, and the following needs to be implemented

- [x] Clearing a cache entirely 
- [ ] Clearing specific entries from the cache

# How

[This suggestion](https://github.com/logaretm/villus/issues/147) has been the best so far as it doesn't include any guessing or being too clever about this. Queries can have "tags" and mutations could also clear those cached query tags.

This probably will have a lot of changes internally however it will be invisible to the end user so it is a great opportunity to try out.

closes #147 #84