### PR TITLE
docs: fix table markdown for use-subscription page

### DIFF
--- a/docs/src/pages/api/use-subscription.mdx
+++ b/docs/src/pages/api/use-subscription.mdx
@@ -21,11 +21,11 @@ The `useSubscription` function returns the following properties and functions:
 
 The `useSubscription` function accepts two arguments, the first being the operation object which contains the following properties:
 
-| Property  | Type                                        | Required        | Description                     |
-| --------- | ------------------------------------------- | --------------- | ------------------------------- | -------------------------------------------------------------------------------------------------- |
-| query     | `string` or `DocumentNode` or `Ref<string>` | **Yes**         | The subscription to be executed |
-| variables | `object` or `Ref<object>`                   | **No**          | The subscription variables      |
-| paused    | `Ref<boolean>`                              | `() => boolean` | **No**                          | If the subscription should be paused, if `true` any incoming values will be ignored by the reducer |
+| Property  | Type                                                      | Required  | Description                     |
+| --------- | --------------------------------------------------------- | --------- | ------------------------------- |
+| query     | `string` or `DocumentNode` or `Ref<string>`               | **Yes**   | The subscription to be executed |
+| variables | `object` or `Ref<object>`                                 | **No**    | The subscription variables      |
+| paused    | `boolean`, `Ref<boolean>` or `({ variables }) => boolean` | **No**    | If the subscription should be paused, if `true` any incoming values will be ignored by the reducer |
 
 The second argument is what is called a `Reducer` which allows you to aggregate subscription results. For more information about that, [check the subscription guide](/guide/subscriptions).
 


### PR DESCRIPTION
Fixes the markdown for the [`use-subscription` page](https://villus.logaretm.com/api/use-subscription/#usage) and uses [the types](https://github.com/logaretm/villus/blob/3b03942b30585b0e5d2aab0456be875281fd53dd/packages/villus/src/types.ts#L81) used for the `paused` field.

<img width="843" alt="Screenshot 2023-02-14 at 22 49 47" src="https://user-images.githubusercontent.com/12190184/218871012-852228a4-ed3e-4d14-9fad-754a0c7687a9.png">
