### PR TITLE
feat(useMutation): export MutationExecutionOptions interface

### DIFF
--- a/packages/villus/src/useMutation.ts
+++ b/packages/villus/src/useMutation.ts
@@ -4,7 +4,7 @@ import { CombinedError } from './utils';
 import { Operation, QueryVariables } from '../../shared/src';
 import { Client, resolveClient } from './client';
 
-interface MutationExecutionOptions<TData> {
+export interface MutationExecutionOptions<TData> {
   context: MaybeRef<QueryExecutionContext>;
   client?: Client;
   clearCacheTags?: string[];


### PR DESCRIPTION
Just a simple export that is needed when we want to override some data or hooks.

Example:

```
import type { Client, CombinedError, MaybeRef, MutationApi, Operation, QueryExecutionContext } from 'villus'
import { useMutation as useMutationRequeset } from 'villus'
import { isNil, omitBy } from 'lodash-es'

// NEED THIS THAT IS NOT EXPORTED ------------------------------>
interface MutationExecutionOptions<TData> {
  context: MaybeRef<QueryExecutionContext>
  client?: Client
  clearCacheTags?: string[]
  refetchTags?: string[]
  onData?: (data: TData) => void
  onError?: (err: CombinedError) => void
}

export function useMutation<TData = any, TVars = any>(
  query: Operation<TData, TVars>['query'],
  // HERE ------------------------------>
  args: Partial<MutationExecutionOptions<TData>>): MutationApi<TData, TVars> {
  const { onData } = args

  return useMutationRequeset<TData, TVars>(unref(query), {
    ...args,
    onData: (data) => {
      // TO DO SOME EXAMPLE OF OVERRIDE THERE ------------------------------>
      if (typeof data === 'object' && !Object.keys(omitBy(data, isNil)).length)
        return
      onData?.(data)
    },
  })
}
```