### PR TITLE
fix: make skip work when execute overrides variables

### DIFF
--- a/packages/villus/src/useQuery.ts
+++ b/packages/villus/src/useQuery.ts
@@ -113,7 +113,7 @@ function useQuery<TData = any, TVars = QueryVariables, TMappedData = TData | nul
   }
 
   async function execute(overrideOpts?: Partial<QueryExecutionOpts<TVars>>) {
-    const vars = toValue(variables) || ({} as TVars);
+    const vars = toValue(overrideOpts?.variables || variables) || ({} as TVars);
     // result won't change if execution is skipped
     if (unravel(skip, vars)) {
       isFetching.value = false;
@@ -128,7 +128,7 @@ function useQuery<TData = any, TVars = QueryVariables, TMappedData = TData | nul
     const pendingExecution = client.executeQuery<TData, TVars>(
       {
         query: toValue(query),
-        variables: toValue(overrideOpts?.variables || vars),
+        variables: vars,
         cachePolicy: overrideOpts?.cachePolicy || cachePolicy,
         tags: opts?.tags,
       },


### PR DESCRIPTION
I noticed the following issue - when `skip` callback uses `variables` being passed in, only the default `variables` that were passed in when `useQuery` was called are checked.

```javascript
const { data, execute } = useQuery({
  query: MyQueryDocument,
  fetchOnMount: false,
  variables: () => { id: 'invalid-id' }
  skip: ({ id }) => id === 'invalid-id' 
})
```

If I try to override `variables` when using `execute`...

```javascript
execute({
  variables: { 
    id: "completely-valid-id" 
  }
})`
```

...the query is still skipped even though the variables passed to `execute` are OK.